### PR TITLE
add Configuration::comment and Configuration::blankLine

### DIFF
--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/feature/config/Configuration.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/feature/config/Configuration.java
@@ -28,6 +28,8 @@ import java.util.List;
 import java.util.Collections;
 import java.util.UUID;
 
+import static io.micronaut.projectgen.core.utils.StringUtils.*;
+
 /**
  * Models application environment configuration to specify where the configuration is rooted for the given configuration values (key/value pairs).
  *
@@ -268,13 +270,13 @@ public class Configuration extends LinkedHashMap<String, Object> {
      * @param comment a comment to a configuration file.
      */
     public void comment(String comment) {
-        put(COMMENT_PREFIX + UUID.randomUUID(), comment);
+        put(COMMENT_PREFIX + randomString(), comment);
     }
 
     /**
      * Add a blank line
      */
     public void blankLine() {
-        put(BLANK_LINE_PREFIX + UUID.randomUUID(), EMPTY_STRING);
+        put(BLANK_LINE_PREFIX + randomString(), EMPTY_STRING);
     }
 }

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/feature/config/Configuration.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/feature/config/Configuration.java
@@ -19,12 +19,14 @@ import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.core.util.StringUtils;
 
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Collections;
+import java.util.UUID;
 
 /**
  * Models application environment configuration to specify where the configuration is rooted for the given configuration values (key/value pairs).
@@ -32,9 +34,14 @@ import java.util.Collections;
  */
 public class Configuration extends LinkedHashMap<String, Object> {
 
+    private static final String EMPTY_STRING = "";
     private final String path;
     private final String fileName;
     private final String templateKey;
+    public static final String COMMENT_PREFIX = "___COMMENT_KEY___";
+    public static final String BLANK_LINE_PREFIX = "___BLANK_LINE__KEY___";
+    public static final List<String> PREFIXES = Arrays.asList(COMMENT_PREFIX, BLANK_LINE_PREFIX);
+
 
     /**
      * A configuration rooted at path, with the given map of configurations.
@@ -254,5 +261,20 @@ public class Configuration extends LinkedHashMap<String, Object> {
             return values;
         }
         return Collections.singletonList(value);
+    }
+
+    /**
+     *
+     * @param comment a comment to a configuration file.
+     */
+    public void comment(String comment) {
+        put(COMMENT_PREFIX + UUID.randomUUID(), comment);
+    }
+
+    /**
+     * Add a blank line
+     */
+    public void blankLine() {
+        put(BLANK_LINE_PREFIX + UUID.randomUUID(), EMPTY_STRING);
     }
 }

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/template/Config4kTemplate.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/template/Config4kTemplate.java
@@ -18,11 +18,14 @@ package io.micronaut.projectgen.core.template;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigRenderOptions;
+import io.micronaut.projectgen.core.feature.config.Configuration;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class Config4kTemplate extends DefaultTemplate {
 
@@ -34,7 +37,17 @@ public class Config4kTemplate extends DefaultTemplate {
 
     public Config4kTemplate(String module, String path, Map<String, Object> values) {
         super(module, path);
-        config = ConfigFactory.parseMap(values);
+        config = ConfigFactory.parseMap(removeCommentsAndBlankLinesEntries(values));
+    }
+
+    private Map<String, Object> removeCommentsAndBlankLinesEntries(Map<String, Object> values) {
+        // Delete unsupported entries (Comments or blank lines)
+        Set<String> keysToBeRemoved = values.keySet().stream()
+            .filter(k -> Configuration.PREFIXES.stream().anyMatch(k::startsWith)).collect(Collectors.toSet());;
+        for (String k : keysToBeRemoved) {
+            values.remove(k);
+        }
+        return values;
     }
 
     @Override

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/template/PropertiesTemplate.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/template/PropertiesTemplate.java
@@ -15,9 +15,15 @@
  */
 package io.micronaut.projectgen.core.template;
 
+import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
+
+import static io.micronaut.projectgen.core.feature.config.Configuration.BLANK_LINE_PREFIX;
+import static io.micronaut.projectgen.core.feature.config.Configuration.COMMENT_PREFIX;
 
 public class PropertiesTemplate extends DefaultTemplate {
 
@@ -74,5 +80,137 @@ public class PropertiesTemplate extends DefaultTemplate {
             keys.add(key);
             return super.put(key, value);
         }
+
+        // Override Properties `store` method to avoid printing date
+        public void store(OutputStream out, String comments)
+            throws IOException {
+            store0(new BufferedWriter(new OutputStreamWriter(out, StandardCharsets.ISO_8859_1)),
+                comments,
+                true);
+        }
+
+        private void store0(BufferedWriter bw, String comments, boolean escUnicode)
+            throws IOException
+        {
+            if (comments != null) {
+                writeComments(bw, comments);
+            }
+            //bw.write("#" + new Date().toString());
+            //bw.newLine();
+            synchronized (this) {
+                for (Object keyObj : this.orderedKeys()) {
+                    String key = keyObj.toString();
+                    String val = getProperty(key);
+                    if (key.startsWith(COMMENT_PREFIX)) {
+                        bw.write("# " + val);
+                        bw.newLine();
+
+                    } else if (key.startsWith(BLANK_LINE_PREFIX)) {
+                        bw.newLine();
+
+                    } else {
+                        key = saveConvert(key, true, escUnicode);
+                        /* No need to escape embedded and trailing spaces for value, hence
+                         * pass false to flag.
+                         */
+                        val = saveConvert(val, false, escUnicode);
+                        bw.write(key + "=" + val);
+                        bw.newLine();
+                    }
+                }
+            }
+            bw.flush();
+        }
     }
+
+    private String saveConvert(String theString,
+                               boolean escapeSpace,
+                               boolean escapeUnicode) {
+        int len = theString.length();
+        int bufLen = len * 2;
+        if (bufLen < 0) {
+            bufLen = Integer.MAX_VALUE;
+        }
+        StringBuilder outBuffer = new StringBuilder(bufLen);
+        HexFormat hex = HexFormat.of().withUpperCase();
+        for(int x=0; x<len; x++) {
+            char aChar = theString.charAt(x);
+            // Handle common case first, selecting largest block that
+            // avoids the specials below
+            if ((aChar > 61) && (aChar < 127)) {
+                if (aChar == '\\') {
+                    outBuffer.append('\\'); outBuffer.append('\\');
+                    continue;
+                }
+                outBuffer.append(aChar);
+                continue;
+            }
+            switch(aChar) {
+                case ' ':
+                    if (x == 0 || escapeSpace)
+                        outBuffer.append('\\');
+                    outBuffer.append(' ');
+                    break;
+                case '\t':outBuffer.append('\\'); outBuffer.append('t');
+                    break;
+                case '\n':outBuffer.append('\\'); outBuffer.append('n');
+                    break;
+                case '\r':outBuffer.append('\\'); outBuffer.append('r');
+                    break;
+                case '\f':outBuffer.append('\\'); outBuffer.append('f');
+                    break;
+                case '=': // Fall through
+                case ':': // Fall through
+                case '#': // Fall through
+                case '!':
+                    outBuffer.append('\\'); outBuffer.append(aChar);
+                    break;
+                default:
+                    if (((aChar < 0x0020) || (aChar > 0x007e)) & escapeUnicode ) {
+                        outBuffer.append("\\u");
+                        outBuffer.append(hex.toHexDigits(aChar));
+                    } else {
+                        outBuffer.append(aChar);
+                    }
+            }
+        }
+        return outBuffer.toString();
+    }
+
+    private static void writeComments(BufferedWriter bw, String comments)
+        throws IOException {
+        HexFormat hex = HexFormat.of().withUpperCase();
+        bw.write("#");
+        int len = comments.length();
+        int current = 0;
+        int last = 0;
+        while (current < len) {
+            char c = comments.charAt(current);
+            if (c > '\u00ff' || c == '\n' || c == '\r') {
+                if (last != current)
+                    bw.write(comments.substring(last, current));
+                if (c > '\u00ff') {
+                    bw.write("\\u");
+                    bw.write(hex.toHexDigits(c));
+                } else {
+                    bw.newLine();
+                    if (c == '\r' &&
+                        current != len - 1 &&
+                        comments.charAt(current + 1) == '\n') {
+                        current++;
+                    }
+                    if (current == len - 1 ||
+                        (comments.charAt(current + 1) != '#' &&
+                            comments.charAt(current + 1) != '!'))
+                        bw.write("#");
+                }
+                last = current + 1;
+            }
+            current++;
+        }
+        if (last != current)
+            bw.write(comments.substring(last, current));
+        bw.newLine();
+    }
+
 }

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/template/TomlTemplate.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/template/TomlTemplate.java
@@ -37,6 +37,7 @@ import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 public class TomlTemplate extends DefaultTemplate {
 
@@ -48,6 +49,13 @@ public class TomlTemplate extends DefaultTemplate {
 
     public TomlTemplate(String module, String path, Configuration config) {
         super(module, path);
+
+        // Delete unsupported entries (Comments or blank lines)
+        Set<String> keysToBeRemoved = config.keySet().stream()
+            .filter(k -> Configuration.PREFIXES.stream().anyMatch(k::startsWith)).collect(Collectors.toSet());;
+        for (String k : keysToBeRemoved) {
+            config.remove(k);
+        }
 
         // normalize config
         Map<DottedKey, Object> normalized = normalizeTopLevel(config);

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/template/YamlTemplate.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/template/YamlTemplate.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.projectgen.core.template;
 
+import io.micronaut.projectgen.core.feature.config.Configuration;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
 
@@ -24,7 +25,11 @@ import java.io.OutputStreamWriter;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.Function;
 import java.util.regex.Pattern;
+
+import static io.micronaut.projectgen.core.feature.config.Configuration.PREFIXES;
 
 public class YamlTemplate extends DefaultTemplate {
 
@@ -64,6 +69,7 @@ public class YamlTemplate extends DefaultTemplate {
     @SuppressWarnings("unchecked")
     protected Map<String, Object> transform(Map<String, Object> config) {
         Map<String, Object> transformed = new LinkedHashMap<>();
+        Function<String, Boolean> SKIP_KEY = s -> PREFIXES.stream().anyMatch(s::startsWith);
         for (Map.Entry<String, Object> entry: config.entrySet()) {
             Map<String, Object> finalMap = transformed;
             String key = entry.getKey();
@@ -72,23 +78,32 @@ public class YamlTemplate extends DefaultTemplate {
             if (index != -1) {
                 String[] keys = DOT_PATTERN.split(key);
                 if (!"micronaut".equals(keys[0]) && config.keySet().stream().filter(k -> k.startsWith(keys[0] + ".")).count() == 1) {
-                    finalMap.put(key, value);
+                    if (!SKIP_KEY.apply(key)) {
+                        finalMap.put(key, value);
+                    }
                 } else {
                     for (int i = 0; i < keys.length - 1; i++) {
                         String subKey = keys[i];
 
                         if (!finalMap.containsKey(subKey)) {
-                            finalMap.put(subKey, new LinkedHashMap<>());
+                            if (!SKIP_KEY.apply(subKey)) {
+                                finalMap.put(subKey, new LinkedHashMap<>());
+                            }
                         }
                         Object next = finalMap.get(subKey);
                         if (next instanceof Map) {
                             finalMap = (Map<String, Object>) next;
                         }
                     }
-                    finalMap.put(keys[keys.length - 1], value);
+                    String k = keys[keys.length - 1];
+                    if (!SKIP_KEY.apply(k)) {
+                        finalMap.put(k, value);
+                    }
                 }
             } else {
-                finalMap.put(key, value);
+                if (!SKIP_KEY.apply(key)) {
+                    finalMap.put(key, value);
+                }
             }
         }
         return transformed;

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/utils/StringUtils.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/utils/StringUtils.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.projectgen.core.utils;
+
+import io.micronaut.core.annotation.Internal;
+
+@Internal
+public final class StringUtils {
+    private StringUtils() {
+
+    }
+
+    /**
+     * @return a random string without using UUID, which brings in crypto libs
+     * and bulks up the web image size
+     */
+    public static String randomString() {
+        return Long.toHexString(System.currentTimeMillis()) + Long.toHexString(System.nanoTime());
+    }
+}

--- a/projectgen-core/src/test/java/io/micronaut/projectgen/core/utils/StringUtilsTest.java
+++ b/projectgen-core/src/test/java/io/micronaut/projectgen/core/utils/StringUtilsTest.java
@@ -1,0 +1,21 @@
+package io.micronaut.projectgen.core.utils;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class StringUtilsTest {
+
+    @Test
+    void randomStringReturnsDifferentStrings() {
+        Set<String> result = new HashSet<>();
+        int count = 100;
+        for (int i = 0; i < count; i++) {
+            result.add(StringUtils.randomString());
+        }
+        assertEquals(count, result.size());
+    }
+}

--- a/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/agorapulse/console/Console.java
+++ b/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/agorapulse/console/Console.java
@@ -86,7 +86,7 @@ public class Console implements AgoraPulseFeature {
 
     @Override
     public void apply(GeneratorContext generatorContext) {
-        String secret = UUID.randomUUID().toString();
+        String secret = io.micronaut.projectgen.core.utils.StringUtils.randomString();
         addDependency(generatorContext);
         addExampleCode(generatorContext, secret);
         addConfiguration(generatorContext, secret);

--- a/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/agorapulse/slack/Slack.java
+++ b/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/agorapulse/slack/Slack.java
@@ -78,6 +78,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 
+import static io.micronaut.projectgen.core.utils.StringUtils.*;
 import static io.micronaut.starter.feature.agorapulse.AgoraPulseFeature.addMain;
 import static io.micronaut.starter.feature.agorapulse.AgoraPulseFeature.addTest;
 import static io.micronaut.starter.feature.agorapulse.AgoraPulseFeature.addTestUtil;
@@ -152,8 +153,8 @@ public class Slack implements AgoraPulseFeature {
 
     private void addConfiguration(GeneratorContext generatorContext) {
         Map<String, String> slack = new LinkedHashMap<>(1);
-        slack.put("bot-token", "xoxb-" + UUID.randomUUID());
-        slack.put("signing-secret", UUID.randomUUID().toString());
+        slack.put("bot-token", "xoxb-" + randomString());
+        slack.put("signing-secret", randomString());
 
         Map<String, Object> nested = new LinkedHashMap<>(1);
         nested.put("slack", slack);

--- a/projectgen-micronaut/src/test/java/io/micronaut/projectgen/core/template/Config4kTemplateTest.java
+++ b/projectgen-micronaut/src/test/java/io/micronaut/projectgen/core/template/Config4kTemplateTest.java
@@ -1,0 +1,60 @@
+package io.micronaut.projectgen.core.template;
+
+import io.micronaut.context.annotation.Property;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.projectgen.core.feature.Feature;
+import io.micronaut.projectgen.core.feature.config.ApplicationConfiguration;
+import io.micronaut.projectgen.core.generator.GeneratorContext;
+import io.micronaut.projectgen.core.io.MapOutputHandler;
+import io.micronaut.projectgen.core.options.Language;
+import io.micronaut.projectgen.micronaut.MicronautOptions;
+import io.micronaut.projectgen.micronaut.MicronautProjectGenerator;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Singleton;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Property(name = "spec.name", value = "Config4kTemplateTest")
+@MicronautTest
+class Config4kTemplateTest {
+
+    @Test
+    void propertyWithComments(MicronautProjectGenerator projectGenerator) throws Exception {
+        MicronautOptions options = MicronautOptions.builder().language(Language.KOTLIN).feature("default-port-feature").feature("config4k").build();
+        MapOutputHandler outputHandler = new MapOutputHandler();
+        projectGenerator.generate(options, outputHandler);
+        Map<String, String> project = outputHandler.getProject();
+        String applicationProperties = project.get("src/main/resources/application.conf");
+        assertEquals("""
+micronaut {
+    application {
+        name=demo
+    }
+    server {
+        port=8090
+    }
+}
+            """, applicationProperties);
+    }
+
+    @Requires(property = "spec.name", value = "Config4kTemplateTest")
+    @Singleton
+    static class ChangeDefaultPortFeature implements Feature {
+
+        @Override
+        public String getName() {
+            return "default-port-feature";
+        }
+
+        @Override
+        public void apply(GeneratorContext generatorContext) {
+            ApplicationConfiguration configuration = generatorContext.getConfiguration();
+            configuration.blankLine();
+            configuration.comment("General Server Configuration");
+            configuration.put("micronaut.server.port", 8090);
+        }
+    }
+}

--- a/projectgen-micronaut/src/test/java/io/micronaut/projectgen/core/template/PropertiesTemplateTest.java
+++ b/projectgen-micronaut/src/test/java/io/micronaut/projectgen/core/template/PropertiesTemplateTest.java
@@ -1,0 +1,55 @@
+package io.micronaut.projectgen.core.template;
+
+import io.micronaut.context.annotation.Property;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.projectgen.core.feature.Feature;
+import io.micronaut.projectgen.core.feature.config.ApplicationConfiguration;
+import io.micronaut.projectgen.core.generator.GeneratorContext;
+import io.micronaut.projectgen.core.io.MapOutputHandler;
+import io.micronaut.projectgen.micronaut.MicronautOptions;
+import io.micronaut.projectgen.micronaut.MicronautProjectGenerator;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Singleton;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Property(name = "spec.name", value = "ProjectTemplateTest")
+@MicronautTest
+class PropertiesTemplateTest {
+
+    @Test
+    void propertyWithComments(MicronautProjectGenerator projectGenerator) throws Exception {
+        MicronautOptions options = MicronautOptions.builder().feature("default-port-feature").build();
+        MapOutputHandler outputHandler = new MapOutputHandler();
+        projectGenerator.generate(options, outputHandler);
+        Map<String, String> project = outputHandler.getProject();
+        String applicationProperties = project.get("src/main/resources/application.properties");
+        assertEquals("""
+            micronaut.application.name=demo
+
+            # General Server Configuration
+            micronaut.server.port=8090
+            """, applicationProperties);
+    }
+
+    @Requires(property = "spec.name", value = "ProjectTemplateTest")
+    @Singleton
+    static class ChangeDefaultPortFeature implements Feature {
+
+        @Override
+        public String getName() {
+            return "default-port-feature";
+        }
+
+        @Override
+        public void apply(GeneratorContext generatorContext) {
+            ApplicationConfiguration configuration = generatorContext.getConfiguration();
+            configuration.blankLine();
+            configuration.comment("General Server Configuration");
+            configuration.put("micronaut.server.port", "8090");
+        }
+    }
+}

--- a/projectgen-micronaut/src/test/java/io/micronaut/projectgen/core/template/TomlTemplateTest.java
+++ b/projectgen-micronaut/src/test/java/io/micronaut/projectgen/core/template/TomlTemplateTest.java
@@ -1,0 +1,58 @@
+package io.micronaut.projectgen.core.template;
+
+import io.micronaut.context.annotation.Property;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.projectgen.core.feature.Feature;
+import io.micronaut.projectgen.core.feature.config.ApplicationConfiguration;
+import io.micronaut.projectgen.core.generator.GeneratorContext;
+import io.micronaut.projectgen.core.io.MapOutputHandler;
+import io.micronaut.projectgen.micronaut.MicronautOptions;
+import io.micronaut.projectgen.micronaut.MicronautProjectGenerator;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Singleton;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Property(name = "spec.name", value = "TomlTemplateTest")
+@MicronautTest
+class TomlTemplateTest {
+
+    @Test
+    void propertyWithComments(MicronautProjectGenerator projectGenerator) throws Exception {
+        MicronautOptions options = MicronautOptions.builder()
+            .feature("default-port-feature")
+            .feature("toml")
+            .build();
+        MapOutputHandler outputHandler = new MapOutputHandler();
+        projectGenerator.generate(options, outputHandler);
+        Map<String, String> project = outputHandler.getProject();
+        String applicationProperties = project.get("src/main/resources/application.toml");
+        assertEquals("""
+
+[micronaut]
+application.name = 'demo'
+server.port = 8090
+""", applicationProperties);
+    }
+
+    @Requires(property = "spec.name", value = "TomlTemplateTest")
+    @Singleton
+    static class ChangeDefaultPortFeature implements Feature {
+
+        @Override
+        public String getName() {
+            return "default-port-feature";
+        }
+
+        @Override
+        public void apply(GeneratorContext generatorContext) {
+            ApplicationConfiguration configuration = generatorContext.getConfiguration();
+            configuration.blankLine();
+            configuration.comment("General Server Configuration");
+            configuration.put("micronaut.server.port", 8090);
+        }
+    }
+}

--- a/projectgen-micronaut/src/test/java/io/micronaut/projectgen/core/template/YamlTemplateTest.java
+++ b/projectgen-micronaut/src/test/java/io/micronaut/projectgen/core/template/YamlTemplateTest.java
@@ -1,0 +1,56 @@
+package io.micronaut.projectgen.core.template;
+
+import io.micronaut.context.annotation.Property;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.projectgen.core.feature.Feature;
+import io.micronaut.projectgen.core.feature.config.ApplicationConfiguration;
+import io.micronaut.projectgen.core.generator.GeneratorContext;
+import io.micronaut.projectgen.core.io.MapOutputHandler;
+import io.micronaut.projectgen.micronaut.MicronautOptions;
+import io.micronaut.projectgen.micronaut.MicronautProjectGenerator;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Singleton;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Property(name = "spec.name", value = "YamlTemplateTest")
+@MicronautTest
+class YamlTemplateTest {
+
+    @Test
+    void propertyWithComments(MicronautProjectGenerator projectGenerator) throws Exception {
+        MicronautOptions options = MicronautOptions.builder().feature("default-port-feature").feature("yaml").build();
+        MapOutputHandler outputHandler = new MapOutputHandler();
+        projectGenerator.generate(options, outputHandler);
+        Map<String, String> project = outputHandler.getProject();
+        String applicationProperties = project.get("src/main/resources/application.yml");
+        assertEquals("""
+micronaut:
+  application:
+    name: demo
+  server:
+    port: 8090
+""", applicationProperties);
+    }
+
+    @Requires(property = "spec.name", value = "YamlTemplateTest")
+    @Singleton
+    static class ChangeDefaultPortFeature implements Feature {
+
+        @Override
+        public String getName() {
+            return "default-port-feature";
+        }
+
+        @Override
+        public void apply(GeneratorContext generatorContext) {
+            ApplicationConfiguration configuration = generatorContext.getConfiguration();
+            configuration.blankLine();
+            configuration.comment("General Server Configuration");
+            configuration.put("micronaut.server.port", 8090);
+        }
+    }
+}


### PR DESCRIPTION
I override `Properties::store` to avoid printing the date also I add support for comment and blank line

For yaml, toml, and config4k I remove comments and blank lines for now. 