### PR TITLE
Fix projectgen build compatibility with micronaut 5

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.projectgen-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.projectgen-module.gradle
@@ -1,3 +1,5 @@
+import org.gradle.api.plugins.quality.Checkstyle
+
 plugins {
     id 'io.micronaut.build.internal.projectgen-base'
     id "io.micronaut.build.internal.module"
@@ -21,6 +23,19 @@ micronautBuild {
 tasks {
     prepareJavadocAggregation {
         sources.from(layout.buildDirectory.dir("generated/sources/annotationProcessor/java/main"))
+    }
+}
+tasks.withType(JavaCompile).configureEach {
+    options.extensions.configure("errorprone") { errorProneOptions ->
+        errorProneOptions.excludedPaths.set(".*/(src/generated/rocker|build/generated[-/]sources)/.*")
+    }
+}
+tasks.withType(Checkstyle).configureEach {
+    source = source.filter { file ->
+        def path = file.absolutePath
+        !path.contains("${File.separator}src${File.separator}generated${File.separator}rocker${File.separator}") &&
+            !path.contains("${File.separator}build${File.separator}generated${File.separator}") &&
+            !path.contains("${File.separator}build${File.separator}generated-sources${File.separator}")
     }
 }
 dependencies {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@
 micronaut = "5.0.0"
 micronaut-platform = "5.0.0"
 rewrite-recipe-bom = "3.22.0"
+rewrite-core = "8.84.0"
 micronaut-serialization = "3.0.0"
 micronaut-views = "6.0.0"
 micronaut-sourcegen = "2.0.0"
@@ -31,7 +32,7 @@ typesafeconfig = { module = "com.typesafe:config", version.ref = "typesafeconfig
 snakeyaml = { module = "org.yaml:snakeyaml", version.ref = "snakeyaml" }
 apache-commons-compress = { module = "org.apache.commons:commons-compress", version.ref = "apache-commons-compress" }
 rewrite-recipe-bom = { module = "org.openrewrite.recipe:rewrite-recipe-bom", version.ref = "rewrite-recipe-bom" }
-rewrite-core = { module = "org.openrewrite:rewrite-core" }
+rewrite-core = { module = "org.openrewrite:rewrite-core", version.ref = "rewrite-core" }
 rewrite-properties = { module = "org.openrewrite:rewrite-properties" }
 rewrite-gradle = { module = "org.openrewrite:rewrite-gradle" }
 rewrite-java-dependencies = { module = "org.openrewrite.recipe:rewrite-java-dependencies" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,10 +1,10 @@
 [versions]
 
 micronaut = "5.0.0"
-micronaut-platform = "5.0.0-RC1"
+micronaut-platform = "5.0.0"
 rewrite-recipe-bom = "3.22.0"
 micronaut-serialization = "3.0.0"
-micronaut-views = "6.0.0-RC1"
+micronaut-views = "6.0.0"
 micronaut-sourcegen = "2.0.0"
 micronaut-logging = "2.0.0"
 micronaut-validation = "5.0.0"

--- a/projectgen-core/build.gradle.kts
+++ b/projectgen-core/build.gradle.kts
@@ -1,3 +1,5 @@
+import net.ltgt.gradle.errorprone.errorprone
+
 plugins {
     id("io.micronaut.build.internal.projectgen-module")
     id("nu.studer.rocker") version "3.3.1"
@@ -53,3 +55,7 @@ val generateCoordinateUtils = tasks.register<io.micronaut.projectgen.coordinates
 }
 
 sourceSets["main"].java.srcDir(generateCoordinateUtils)
+
+tasks.withType<JavaCompile>().configureEach {
+    options.errorprone.excludedPaths.set(".*/(src/generated/rocker|build/generated[-/]sources)/.*")
+}

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/BuildPlugin.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/BuildPlugin.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.projectgen.core.buildtools;
 
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import io.micronaut.core.order.Ordered;
 import io.micronaut.projectgen.core.buildtools.dependencies.CoordinateResolver;
@@ -25,6 +26,7 @@ import io.micronaut.projectgen.core.template.Writable;
  */
 public interface BuildPlugin extends Ordered {
 
+    @NonNull
     BuildTool getBuildTool();
 
     @Nullable

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/BuildPlugin.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/BuildPlugin.java
@@ -15,8 +15,7 @@
  */
 package io.micronaut.projectgen.core.buildtools;
 
-import io.micronaut.core.annotation.NonNull;
-import io.micronaut.core.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import io.micronaut.core.order.Ordered;
 import io.micronaut.projectgen.core.buildtools.dependencies.CoordinateResolver;
 import io.micronaut.projectgen.core.template.Writable;
@@ -26,7 +25,6 @@ import io.micronaut.projectgen.core.template.Writable;
  */
 public interface BuildPlugin extends Ordered {
 
-    @NonNull
     BuildTool getBuildTool();
 
     @Nullable

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/BuildTool.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/BuildTool.java
@@ -15,7 +15,7 @@
  */
 package io.micronaut.projectgen.core.buildtools;
 
-import io.micronaut.core.annotation.NonNull;
+import org.jspecify.annotations.NonNull;
 import io.micronaut.core.util.StringUtils;
 import java.util.Locale;
 import java.util.Optional;
@@ -43,13 +43,11 @@ public enum BuildTool {
         return getName();
     }
 
-    @NonNull
-    public String getName() {
+    public @NonNull String getName() {
         return name().toLowerCase(Locale.ENGLISH);
     }
 
-    @NonNull
-    public static Optional<BuildTool> of(@NonNull String str) {
+    public static @NonNull Optional<BuildTool> of(@NonNull String str) {
         for (BuildTool bt : values()) {
             if (bt.name().equalsIgnoreCase(str)) {
                 return Optional.of(bt);

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/BuildToolUtils.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/BuildToolUtils.java
@@ -15,8 +15,8 @@
  */
 package io.micronaut.projectgen.core.buildtools;
 
-import io.micronaut.core.annotation.NonNull;
-import io.micronaut.core.annotation.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import io.micronaut.projectgen.core.buildtools.gradle.GradleDsl;
 
 /**
@@ -37,8 +37,7 @@ public final class BuildToolUtils {
      * @param dsl Gradle DSL
      * @return settings file name. e.g. settings.gradle
      */
-    @NonNull
-    public static String settingsFileName(@NonNull BuildTool buildTool, @Nullable GradleDsl dsl) {
+    public static @NonNull String settingsFileName(@NonNull BuildTool buildTool, @Nullable GradleDsl dsl) {
         return settingsFileNameWithoutExtension(buildTool) + fileExtension(buildTool, dsl);
     }
 
@@ -48,14 +47,12 @@ public final class BuildToolUtils {
      * @param dsl Gradle DSL
      * @return build file name. e.g. pom.xml or build.gradle
      */
-    @NonNull
-    public static String buildFileName(@NonNull BuildTool buildTool,
+    public static @NonNull String buildFileName(@NonNull BuildTool buildTool,
                                        @Nullable GradleDsl dsl) {
         return buildFileNameWithoutExtension(buildTool) + fileExtension(buildTool, dsl);
     }
 
-    @NonNull
-    private static String fileExtension(@NonNull BuildTool buildTool,
+    private static @NonNull String fileExtension(@NonNull BuildTool buildTool,
                                           @Nullable GradleDsl dsl) {
         return switch (buildTool) {
             case GRADLE -> {
@@ -76,16 +73,14 @@ public final class BuildToolUtils {
         };
     }
 
-    @NonNull
-    private static String buildFileNameWithoutExtension(@NonNull BuildTool buildTool) {
+    private static @NonNull String buildFileNameWithoutExtension(@NonNull BuildTool buildTool) {
         return switch (buildTool) {
             case GRADLE -> "build";
             case MAVEN -> "pom";
         };
     }
 
-    @NonNull
-    private static String settingsFileNameWithoutExtension(@NonNull BuildTool buildTool) {
+    private static @NonNull String settingsFileNameWithoutExtension(@NonNull BuildTool buildTool) {
         return switch (buildTool) {
             case GRADLE -> "settings";
             case MAVEN ->  throw new IllegalStateException("no settings file for maven builds");

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/Comment.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/Comment.java
@@ -15,17 +15,21 @@
  */
 package io.micronaut.projectgen.core.buildtools;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Comment.
  */
 public interface Comment extends Property {
 
     @Override
+    @Nullable
     default String getKey() {
         return null;
     }
 
     @Override
+    @Nullable
     default String getValue() {
         return null;
     }

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/Dockerfile.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/Dockerfile.java
@@ -15,8 +15,8 @@
  */
 package io.micronaut.projectgen.core.buildtools;
 
-import io.micronaut.core.annotation.NonNull;
-import io.micronaut.core.annotation.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -66,8 +66,7 @@ public class Dockerfile {
         return args;
     }
 
-    @NonNull
-    public static Builder builder() {
+    public static @NonNull Builder builder() {
         return new Builder();
     }
 
@@ -76,8 +75,11 @@ public class Dockerfile {
      */
     public static class Builder {
 
+        @Nullable
         private String baseImage;
+        @Nullable
         private String javaVersion;
+        @Nullable
         private List<String> args;
 
         /**
@@ -85,8 +87,7 @@ public class Dockerfile {
          * @param baseImage base image
          * @return builder
          */
-        @NonNull
-        public Builder baseImage(String baseImage) {
+        public @NonNull Builder baseImage(String baseImage) {
             this.baseImage = baseImage;
             return this;
         }
@@ -106,8 +107,7 @@ public class Dockerfile {
          * @param arg arg
          * @return builder
          */
-        @NonNull
-        public Builder arg(String arg) {
+        public @NonNull Builder arg(String arg) {
             if (args == null) {
                 args = new ArrayList<>();
             }
@@ -120,8 +120,7 @@ public class Dockerfile {
          * @param args arguments
          * @return builder
          */
-        @NonNull
-        public Builder args(List<String> args) {
+        public @NonNull Builder args(List<String> args) {
             this.args = args;
             return this;
         }
@@ -130,8 +129,7 @@ public class Dockerfile {
          *
          * @return Dockerfile
          */
-        @NonNull
-        public Dockerfile build() {
+        public @NonNull Dockerfile build() {
             return new Dockerfile(baseImage, javaVersion, args);
         }
     }

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/MavenCentral.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/MavenCentral.java
@@ -15,7 +15,7 @@
  */
 package io.micronaut.projectgen.core.buildtools;
 
-import io.micronaut.core.annotation.NonNull;
+import org.jspecify.annotations.NonNull;
 
 /**
  * Maven Central.
@@ -26,14 +26,12 @@ public class MavenCentral implements Repository {
     public static final String MAVEN_CENTRAL_ID = "central";
 
     @Override
-    @NonNull
-    public String getId() {
+    public @NonNull String getId() {
         return MAVEN_CENTRAL_ID;
     }
 
     @Override
-    @NonNull
-    public String getUrl() {
+    public @NonNull String getUrl() {
         return URL;
     }
 }

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/MavenLocal.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/MavenLocal.java
@@ -15,21 +15,19 @@
  */
 package io.micronaut.projectgen.core.buildtools;
 
-import io.micronaut.core.annotation.NonNull;
+import org.jspecify.annotations.NonNull;
 
 /**
  * Maven Local.
  */
 public class MavenLocal implements Repository {
     @Override
-    @NonNull
-    public String getId() {
+    public @NonNull String getId() {
         return "local";
     }
 
     @Override
-    @NonNull
-    public String getUrl() {
+    public @NonNull String getUrl() {
         return "${user.home}/.m2/repository/";
     }
 }

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/Property.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/Property.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.projectgen.core.buildtools;
 
+import org.jspecify.annotations.Nullable;
 /**
  * Build tool property.
  */
@@ -24,18 +25,21 @@ public interface Property {
      *
      * @return Property key
      */
+    @Nullable
     String getKey();
 
     /**
      *
      * @return Property value
      */
+    @Nullable
     String getValue();
 
     /**
      *
      * @return comment
      */
+    @Nullable
     default String getComment() {
         return null;
     }

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/Repository.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/Repository.java
@@ -15,17 +15,13 @@
  */
 package io.micronaut.projectgen.core.buildtools;
 
-import io.micronaut.core.annotation.NonNull;
-
 /**
  * Repository.
  */
 public interface Repository {
 
-    @NonNull
     String getId();
 
-    @NonNull
     String getUrl();
 
     default boolean isSnapshot() {

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/Repository.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/Repository.java
@@ -15,13 +15,17 @@
  */
 package io.micronaut.projectgen.core.buildtools;
 
+import org.jspecify.annotations.NonNull;
+
 /**
  * Repository.
  */
 public interface Repository {
 
+    @NonNull
     String getId();
 
+    @NonNull
     String getUrl();
 
     default boolean isSnapshot() {

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/RequiresRepository.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/RequiresRepository.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.projectgen.core.buildtools;
 
+import org.jspecify.annotations.NonNull;
 import io.micronaut.projectgen.core.feature.Feature;
 import java.util.List;
 
@@ -23,5 +24,6 @@ import java.util.List;
  */
 public interface RequiresRepository extends Feature {
 
+    @NonNull
     List<Repository> getRepositories();
 }

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/RequiresRepository.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/RequiresRepository.java
@@ -15,7 +15,6 @@
  */
 package io.micronaut.projectgen.core.buildtools;
 
-import io.micronaut.core.annotation.NonNull;
 import io.micronaut.projectgen.core.feature.Feature;
 import java.util.List;
 
@@ -24,6 +23,5 @@ import java.util.List;
  */
 public interface RequiresRepository extends Feature {
 
-    @NonNull
     List<Repository> getRepositories();
 }

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/Scope.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/Scope.java
@@ -15,7 +15,7 @@
  */
 package io.micronaut.projectgen.core.buildtools;
 
-import io.micronaut.core.annotation.NonNull;
+import org.jspecify.annotations.NonNull;
 import io.micronaut.core.order.Ordered;
 
 import java.util.Arrays;
@@ -45,11 +45,9 @@ public class Scope implements Ordered {
 
     public static final Scope TEST_RESOURCES_SERVICE = new Scope(Source.MAIN, Collections.singletonList(Phase.TEST_RESOURCES_SERVICE), 13);
 
-    @NonNull
-    private Source source;
+    private @NonNull Source source;
 
-    @NonNull
-    private List<Phase> phases;
+    private @NonNull List<Phase> phases;
 
     private final Integer order;
 
@@ -70,8 +68,7 @@ public class Scope implements Ordered {
      *
      * @return Source
      */
-    @NonNull
-    public Source getSource() {
+    public @NonNull Source getSource() {
         return source;
     }
 
@@ -87,8 +84,7 @@ public class Scope implements Ordered {
      *
      * @return Phases
      */
-    @NonNull
-    public List<Phase> getPhases() {
+    public @NonNull List<Phase> getPhases() {
         return phases;
     }
 

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/dependencies/Coordinate.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/dependencies/Coordinate.java
@@ -16,6 +16,7 @@
 package io.micronaut.projectgen.core.buildtools.dependencies;
 
 import io.micronaut.core.annotation.Introspected;
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import io.micronaut.core.order.OrderUtil;
 
@@ -47,6 +48,7 @@ public interface Coordinate {
     @Nullable
     String getGroupId();
 
+    @NonNull
     String getArtifactId();
 
     @Nullable

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/dependencies/Coordinate.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/dependencies/Coordinate.java
@@ -16,8 +16,7 @@
 package io.micronaut.projectgen.core.buildtools.dependencies;
 
 import io.micronaut.core.annotation.Introspected;
-import io.micronaut.core.annotation.NonNull;
-import io.micronaut.core.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import io.micronaut.core.order.OrderUtil;
 
 import java.util.Comparator;
@@ -48,7 +47,6 @@ public interface Coordinate {
     @Nullable
     String getGroupId();
 
-    @NonNull
     String getArtifactId();
 
     @Nullable

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/dependencies/DefaultCoordinateResolver.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/dependencies/DefaultCoordinateResolver.java
@@ -16,7 +16,7 @@
 package io.micronaut.projectgen.core.buildtools.dependencies;
 
 import io.micronaut.context.annotation.Primary;
-import io.micronaut.core.annotation.NonNull;
+import org.jspecify.annotations.NonNull;
 import jakarta.inject.Singleton;
 
 import java.util.Arrays;
@@ -44,8 +44,8 @@ public class DefaultCoordinateResolver implements CoordinateResolver {
      * @param artifactId artifact ID
      * @return Coordinate
      */
-    @NonNull
-    public Optional<Coordinate> resolve(@NonNull String artifactId) {
+    @Override
+    public @NonNull Optional<Coordinate> resolve(@NonNull String artifactId) {
         return Arrays.stream(coordinateResolvers)
             .map(resolver -> resolver.resolve(artifactId))
             .filter(Optional::isPresent)

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/dependencies/DefaultPomDependencyVersionResolver.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/dependencies/DefaultPomDependencyVersionResolver.java
@@ -15,7 +15,7 @@
  */
 package io.micronaut.projectgen.core.buildtools.dependencies;
 
-import io.micronaut.core.annotation.NonNull;
+import org.jspecify.annotations.NonNull;
 import io.micronaut.projectgen.build.dependencies.StarterCoordinates;
 import jakarta.inject.Singleton;
 import java.util.Map;
@@ -32,8 +32,7 @@ public class DefaultPomDependencyVersionResolver implements PomDependencyVersion
     private static final Map<String, Coordinate> COORDINATES = StarterCoordinates.ALL_COORDINATES;
 
     @Override
-    @NonNull
-    public Optional<Coordinate> resolve(@NonNull String artifactId) {
+    public @NonNull Optional<Coordinate> resolve(@NonNull String artifactId) {
         return Optional.ofNullable(COORDINATES.get(artifactId));
     }
 
@@ -41,8 +40,8 @@ public class DefaultPomDependencyVersionResolver implements PomDependencyVersion
      *
      * @return coordinates
      */
-    @NonNull
-    public Map<String, Coordinate> getCoordinates() {
+    @Override
+    public @NonNull Map<String, Coordinate> getCoordinates() {
         return COORDINATES;
     }
 }

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/dependencies/Dependency.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/dependencies/Dependency.java
@@ -15,8 +15,8 @@
  */
 package io.micronaut.projectgen.core.buildtools.dependencies;
 
-import io.micronaut.core.annotation.NonNull;
-import io.micronaut.core.annotation.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import io.micronaut.projectgen.core.buildtools.Scope;
 
 import java.util.ArrayList;
@@ -31,7 +31,7 @@ import java.util.Objects;
 public final class Dependency implements Coordinate {
 
     public static final Comparator<Dependency> COMPARATOR = (o1, o2) -> {
-        int comparison = Integer.compare(o1.getScope().getOrder(), o2.getScope().getOrder());
+        int comparison = Integer.compare(scopeOrder(o1), scopeOrder(o2));
         if (comparison != 0) {
             return comparison;
         }
@@ -44,8 +44,7 @@ public final class Dependency implements Coordinate {
     @Nullable
     private final String groupId;
 
-    @NonNull
-    private final String artifactId;
+    private final @NonNull String artifactId;
 
     @Nullable
     private final String version;
@@ -70,11 +69,11 @@ public final class Dependency implements Coordinate {
     private final List<Substitution> substitutions;
 
     @SuppressWarnings("ParameterNumber")
-    private Dependency(Scope scope,
+    private Dependency(@Nullable Scope scope,
                        @Nullable String groupId,
                        String artifactId,
-                       String version,
-                       String versionProperty,
+                       @Nullable String version,
+                       @Nullable String versionProperty,
                        boolean requiresLookup,
                        boolean annotationProcessorPriority,
                        int order,
@@ -96,6 +95,11 @@ public final class Dependency implements Coordinate {
         this.substitutions = substitutions;
         this.project = project;
         this.comment = comment;
+    }
+
+    private static int scopeOrder(Dependency dependency) {
+        Scope scope = dependency.getScope();
+        return scope == null ? Integer.MAX_VALUE : scope.getOrder();
     }
 
     @Override
@@ -121,7 +125,7 @@ public final class Dependency implements Coordinate {
         if (pom != that.pom) {
             return false;
         }
-        if (scope != null ? !scope.equals(that.scope) : that.scope != null) {
+        if (!Objects.equals(scope, that.scope)) {
             return false;
         }
         if (project != null ? !project.equals(that.project) : that.project != null) {
@@ -176,10 +180,12 @@ public final class Dependency implements Coordinate {
         return substitutions;
     }
 
+    @Nullable
     public Scope getScope() {
         return scope;
     }
 
+    @Nullable
     public String getComment() {
         return comment;
     }
@@ -270,19 +276,28 @@ public final class Dependency implements Coordinate {
      */
     public static class Builder {
 
+        @Nullable
         private Scope scope;
+        @Nullable
         private String groupId;
+        @Nullable
         private String artifactId;
+        @Nullable
         private String version;
+        @Nullable
         private String versionProperty;
         private boolean requiresLookup;
         private int order;
         private boolean template;
         private boolean annotationProcessorPriority;
         private boolean pom;
+        @Nullable
         private List<Dependency> exclusions;
+        @Nullable
         private List<Substitution> substitutions;
+        @Nullable
         private String project;
+        @Nullable
         private String comment;
 
         /**
@@ -579,8 +594,7 @@ public final class Dependency implements Coordinate {
          * @return instantiate Dependency
          */
         public Dependency build() {
-            Objects.requireNonNull(artifactId, "The artifact id must be set");
-            return buildInternal();
+            return buildInternal(Objects.requireNonNull(artifactId, "The artifact id must be set"));
         }
 
         /**
@@ -596,12 +610,10 @@ public final class Dependency implements Coordinate {
          * @return Dependency Coordinate
          */
         public DependencyCoordinate buildCoordinate(boolean showVersionProperty) {
-            Objects.requireNonNull(artifactId, "The artifact id must be set");
-
-            return new DependencyCoordinate(buildInternal(), showVersionProperty);
+            return new DependencyCoordinate(buildInternal(Objects.requireNonNull(artifactId, "The artifact id must be set")), showVersionProperty);
         }
 
-        private Dependency buildInternal() {
+        private Dependency buildInternal(String artifactId) {
             return new Dependency(
                 scope,
                 groupId,
@@ -619,7 +631,11 @@ public final class Dependency implements Coordinate {
         }
 
         private Builder copy() {
-            Builder builder = new Builder().scope(scope);
+            Builder builder = new Builder();
+            String artifactId = Objects.requireNonNull(this.artifactId, "The artifact id must be set");
+            if (scope != null) {
+                builder.scope(scope);
+            }
             if (requiresLookup) {
                 builder.lookupArtifactId(artifactId);
             } else {

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/dependencies/DependencyContext.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/dependencies/DependencyContext.java
@@ -43,13 +43,15 @@ public interface DependencyContext {
         d.getScope().getPhases().contains(Phase.PUBLIC_API) ||
         d.getScope().getPhases().contains(RUNTIME));
 
+    @NonNull
     Collection<Dependency> getDependencies();
 
+    @NonNull
     Collection<Dependency> getDependenciesByBuildTool(@NonNull BuildTool buildTool);
 
     void addDependency(@NonNull Dependency dependency);
 
-    default void addDependency(Dependency.Builder dependency) {
+    default void addDependency(Dependency.@NonNull Builder dependency) {
         addDependency(dependency.build());
     }
 
@@ -128,7 +130,7 @@ public interface DependencyContext {
 
     void addDependencyOnlyForBuild(@NonNull Dependency dependency, @NonNull BuildTool buildTool);
 
-    default void addDependencyOnlyForBuild(Dependency.Builder dependency, @NonNull BuildTool buildTool) {
+    default void addDependencyOnlyForBuild(Dependency.@NonNull Builder dependency, @NonNull BuildTool buildTool) {
         addDependencyOnlyForBuild(dependency.build(), buildTool);
     }
 }

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/dependencies/DependencyContext.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/dependencies/DependencyContext.java
@@ -15,7 +15,7 @@
  */
 package io.micronaut.projectgen.core.buildtools.dependencies;
 
-import io.micronaut.core.annotation.NonNull;
+import org.jspecify.annotations.NonNull;
 import io.micronaut.projectgen.core.buildtools.BuildTool;
 import io.micronaut.projectgen.core.buildtools.Phase;
 import io.micronaut.projectgen.core.buildtools.Scope;
@@ -27,6 +27,8 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Predicate;
 
 import static io.micronaut.projectgen.core.buildtools.Phase.COMPILATION;
@@ -37,29 +39,26 @@ import static io.micronaut.projectgen.core.buildtools.Phase.RUNTIME;
  */
 public interface DependencyContext {
 
-    Predicate<Dependency> IS_COMPILE_API_OR_RUNTIME = d -> d.getScope().getPhases().contains(COMPILATION) ||
+    Predicate<Dependency> IS_COMPILE_API_OR_RUNTIME = d -> d.getScope() != null && (d.getScope().getPhases().contains(COMPILATION) ||
         d.getScope().getPhases().contains(Phase.PUBLIC_API) ||
-        d.getScope().getPhases().contains(RUNTIME);
+        d.getScope().getPhases().contains(RUNTIME));
 
-    @NonNull
     Collection<Dependency> getDependencies();
 
-    @NonNull
     Collection<Dependency> getDependenciesByBuildTool(@NonNull BuildTool buildTool);
 
     void addDependency(@NonNull Dependency dependency);
 
-    default void addDependency(@NonNull Dependency.Builder dependency) {
+    default void addDependency(Dependency.Builder dependency) {
         addDependency(dependency.build());
     }
 
-    @NonNull
-    default List<Dependency> removeDuplicates(Collection<Dependency> dependencies, Language language, BuildTool buildTool) {
+    default @NonNull List<Dependency> removeDuplicates(Collection<Dependency> dependencies, Language language, BuildTool buildTool) {
 
         List<Dependency> dependenciesNotInMainOrTestClasspath = dependencies.stream()
             .filter(d -> {
                 if (language == Language.GROOVY && buildTool == BuildTool.MAVEN) {
-                    return !IS_COMPILE_API_OR_RUNTIME.test(d) && !d.getScope().getPhases().contains(Phase.ANNOTATION_PROCESSING);
+                    return !IS_COMPILE_API_OR_RUNTIME.test(d) && (d.getScope() == null || !d.getScope().getPhases().contains(Phase.ANNOTATION_PROCESSING));
                 }
                 return !IS_COMPILE_API_OR_RUNTIME.test(d);
             })
@@ -67,7 +66,7 @@ public interface DependencyContext {
 
         List<Dependency> dependenciesInMainClasspath = dependencies.stream()
             .filter(d -> {
-                if (d.getScope().getSource() != Source.MAIN) {
+                if (d.getScope() == null || d.getScope().getSource() != Source.MAIN) {
                     return false;
                 }
                 if (language == Language.GROOVY && buildTool == BuildTool.MAVEN) {
@@ -80,22 +79,17 @@ public interface DependencyContext {
         List<Dependency> dependenciesInMainClasspathWithoutDuplicates = filterDuplicates(dependenciesInMainClasspath);
 
         List<Dependency> dependenciesInTestClasspath = dependencies.stream()
-            .filter(d -> d.getScope().getSource() == Source.TEST && IS_COMPILE_API_OR_RUNTIME.test(d))
+            .filter(d -> d.getScope() != null && d.getScope().getSource() == Source.TEST && IS_COMPILE_API_OR_RUNTIME.test(d))
             .toList();
 
         List<Dependency> dependenciesInTestClasspathWithoutDuplicates = filterDuplicates(dependenciesInTestClasspath);
 
-        dependenciesInTestClasspathWithoutDuplicates.removeIf(testDep -> {
-            MavenCoordinate test = new MavenCoordinate(testDep.getGroupId(), testDep.getArtifactId(), testDep.getVersion());
-            return dependenciesInMainClasspathWithoutDuplicates.stream()
-                .filter(mainDep ->
-                    (buildTool == BuildTool.MAVEN && mainDep.getScope().getPhases().contains(RUNTIME)) ||
-                        (mainDep.getScope().getPhases().contains(RUNTIME) && mainDep.getScope().getPhases().contains(COMPILATION))
-                ).anyMatch(mainDep -> {
-                    MavenCoordinate main = new MavenCoordinate(mainDep.getGroupId(), mainDep.getArtifactId(), mainDep.getVersion());
-                    return main.equals(test);
-                });
-        });
+        dependenciesInTestClasspathWithoutDuplicates.removeIf(testDep -> dependenciesInMainClasspathWithoutDuplicates.stream()
+            .filter(mainDep -> {
+                Scope scope = Objects.requireNonNull(mainDep.getScope());
+                return (buildTool == BuildTool.MAVEN && scope.getPhases().contains(RUNTIME)) ||
+                    (scope.getPhases().contains(RUNTIME) && scope.getPhases().contains(COMPILATION));
+            }).anyMatch(mainDep -> sameCoordinate(mainDep, testDep)));
         List<Dependency> result = new ArrayList<>(dependenciesNotInMainOrTestClasspath);
         result.addAll(dependenciesInMainClasspathWithoutDuplicates);
         result.addAll(dependenciesInTestClasspathWithoutDuplicates);
@@ -104,27 +98,37 @@ public interface DependencyContext {
 
     private static List<Dependency> filterDuplicates(List<Dependency> dependencies) {
         List<Dependency> dependenciesWithoutDuplicates = new ArrayList<>();
-        Map<MavenCoordinate, Scope> dependenciesWithScope = new HashMap<>();
-        for (Dependency dep : dependencies.stream().sorted(Dependency.COMPARATOR).toList()) {
-            MavenCoordinate coordinate = new MavenCoordinate(dep.getGroupId(), dep.getArtifactId(), dep.getVersion());
-            if (dependenciesWithScope.containsKey(coordinate)) {
-                if (dependenciesWithScope.get(coordinate).getOrder() < dep.getOrder()) {
-                    dependenciesWithScope.remove(coordinate);
-                    dependenciesWithoutDuplicates.removeIf(f -> new MavenCoordinate(f.getGroupId(), f.getArtifactId(), f.getVersion()).equals(coordinate));
-                    dependenciesWithScope.put(coordinate, dep.getScope());
+        Map<Dependency, Scope> dependenciesWithScope = new HashMap<>();
+        for (Dependency dep : dependencies.stream().filter(dep -> dep.getScope() != null).sorted(Dependency.COMPARATOR).toList()) {
+            Optional<Dependency> duplicate = dependenciesWithScope.keySet()
+                .stream()
+                .filter(candidate -> sameCoordinate(candidate, dep))
+                .findFirst();
+            if (duplicate.isPresent()) {
+                Dependency duplicateDependency = duplicate.get();
+                if (Objects.requireNonNull(dependenciesWithScope.get(duplicateDependency)).getOrder() < dep.getOrder()) {
+                    dependenciesWithScope.remove(duplicateDependency);
+                    dependenciesWithoutDuplicates.removeIf(f -> sameCoordinate(f, dep));
+                    dependenciesWithScope.put(dep, Objects.requireNonNull(dep.getScope()));
                     dependenciesWithoutDuplicates.add(dep);
                 }
             } else {
-                dependenciesWithScope.put(coordinate, dep.getScope());
+                dependenciesWithScope.put(dep, Objects.requireNonNull(dep.getScope()));
                 dependenciesWithoutDuplicates.add(dep);
             }
         }
         return dependenciesWithoutDuplicates;
     }
 
+    private static boolean sameCoordinate(Dependency left, Dependency right) {
+        return Objects.equals(left.getGroupId(), right.getGroupId()) &&
+            left.getArtifactId().equals(right.getArtifactId()) &&
+            Objects.equals(left.getVersion(), right.getVersion());
+    }
+
     void addDependencyOnlyForBuild(@NonNull Dependency dependency, @NonNull BuildTool buildTool);
 
-    default void addDependencyOnlyForBuild(@NonNull Dependency.Builder dependency, @NonNull BuildTool buildTool) {
+    default void addDependencyOnlyForBuild(Dependency.Builder dependency, @NonNull BuildTool buildTool) {
         addDependencyOnlyForBuild(dependency.build(), buildTool);
     }
 }

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/dependencies/DependencyContextImpl.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/dependencies/DependencyContextImpl.java
@@ -15,7 +15,7 @@
  */
 package io.micronaut.projectgen.core.buildtools.dependencies;
 
-import io.micronaut.core.annotation.NonNull;
+import org.jspecify.annotations.NonNull;
 import io.micronaut.projectgen.core.buildtools.BuildTool;
 
 import java.util.Collection;
@@ -56,15 +56,13 @@ public class DependencyContextImpl implements DependencyContext {
             .add(resolveDependency(dependency));
     }
 
-    @NonNull
     @Override
-    public Set<Dependency> getDependencies() {
+    public @NonNull Set<Dependency> getDependencies() {
         return dependencies;
     }
 
     @Override
-    @NonNull
-    public Collection<Dependency> getDependenciesByBuildTool(@NonNull BuildTool buildTool) {
+    public @NonNull Collection<Dependency> getDependenciesByBuildTool(@NonNull BuildTool buildTool) {
         Set<Dependency> result = new HashSet<>();
         result.addAll(dependencies);
         Collection<Dependency> dependencyByBuildTools = dependenciesByTool.get(buildTool);

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/dependencies/DependencyCoordinate.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/dependencies/DependencyCoordinate.java
@@ -16,8 +16,8 @@
 package io.micronaut.projectgen.core.buildtools.dependencies;
 
 import io.micronaut.core.annotation.Introspected;
-import io.micronaut.core.annotation.NonNull;
-import io.micronaut.core.annotation.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import io.micronaut.core.order.Ordered;
 
 import java.util.List;
@@ -128,9 +128,8 @@ public class DependencyCoordinate implements Coordinate, Ordered {
         return groupId;
     }
 
-    @NonNull
     @Override
-    public String getArtifactId() {
+    public @NonNull String getArtifactId() {
         return artifactId;
     }
 

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/dependencies/MavenCoordinate.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/dependencies/MavenCoordinate.java
@@ -16,8 +16,8 @@
 package io.micronaut.projectgen.core.buildtools.dependencies;
 
 import io.micronaut.core.annotation.Introspected;
-import io.micronaut.core.annotation.NonNull;
-import io.micronaut.core.annotation.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Maven Coordinate.

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/dependencies/PomDependencyVersionResolver.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/dependencies/PomDependencyVersionResolver.java
@@ -15,11 +15,14 @@
  */
 package io.micronaut.projectgen.core.buildtools.dependencies;
 
+import org.jspecify.annotations.NonNull;
+
 import java.util.Map;
 
 /**
  * Resolves the versions of dependencies from a POM file.
  */
 public interface PomDependencyVersionResolver extends CoordinateResolver {
+    @NonNull
     Map<String, Coordinate> getCoordinates();
 }

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/dependencies/PomDependencyVersionResolver.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/dependencies/PomDependencyVersionResolver.java
@@ -15,13 +15,11 @@
  */
 package io.micronaut.projectgen.core.buildtools.dependencies;
 
-import io.micronaut.core.annotation.NonNull;
 import java.util.Map;
 
 /**
  * Resolves the versions of dependencies from a POM file.
  */
 public interface PomDependencyVersionResolver extends CoordinateResolver {
-    @NonNull
     Map<String, Coordinate> getCoordinates();
 }

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/dependencies/Substitution.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/dependencies/Substitution.java
@@ -15,7 +15,8 @@
  */
 package io.micronaut.projectgen.core.buildtools.dependencies;
 
-import io.micronaut.core.annotation.NonNull;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Objects;
 
@@ -24,11 +25,9 @@ import java.util.Objects;
  */
 public class Substitution {
 
-    @NonNull
-    private final Dependency target;
+    private final @NonNull Dependency target;
 
-    @NonNull
-    private final Dependency replacement;
+    private final @NonNull Dependency replacement;
 
     Substitution(@NonNull Dependency target,
                  @NonNull Dependency replacement) {
@@ -40,8 +39,7 @@ public class Substitution {
      *
      * @return Target Dependency
      */
-    @NonNull
-    public Dependency getTarget() {
+    public @NonNull Dependency getTarget() {
         return target;
     }
 
@@ -49,8 +47,7 @@ public class Substitution {
      *
      * @return Replacement
      */
-    @NonNull
-    public Dependency getReplacement() {
+    public @NonNull Dependency getReplacement() {
         return replacement;
     }
 
@@ -58,8 +55,7 @@ public class Substitution {
      *
      * @return The Builder
      */
-    @NonNull
-    public static Builder builder() {
+    public static @NonNull Builder builder() {
         return new Builder();
     }
 
@@ -91,7 +87,9 @@ public class Substitution {
      * Builder.
      */
     public static class Builder {
+        @Nullable
         private Dependency target;
+        @Nullable
         private Dependency replacement;
 
         /**
@@ -99,8 +97,7 @@ public class Substitution {
          * @param target Target
          * @return Builder
          */
-        @NonNull
-        public Builder target(@NonNull Dependency target) {
+        public @NonNull Builder target(@NonNull Dependency target) {
             this.target = target;
             return this;
         }
@@ -110,8 +107,7 @@ public class Substitution {
          * @param replacement Replacement
          * @return Builder
          */
-        @NonNull
-        public Builder replacement(@NonNull Dependency replacement) {
+        public @NonNull Builder replacement(@NonNull Dependency replacement) {
             this.replacement = replacement;
             return this;
         }
@@ -120,8 +116,7 @@ public class Substitution {
          *
          * @return Substitution
          */
-        @NonNull
-        public Substitution build() {
+        public @NonNull Substitution build() {
             return new Substitution(Objects.requireNonNull(target),
                 Objects.requireNonNull(replacement));
         }

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/gradle/Gradle.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/gradle/Gradle.java
@@ -16,7 +16,7 @@
 package io.micronaut.projectgen.core.buildtools.gradle;
 
 import io.micronaut.context.annotation.Requires;
-import io.micronaut.core.annotation.NonNull;
+import org.jspecify.annotations.NonNull;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.projectgen.core.buildtools.BuildTool;
 import io.micronaut.projectgen.core.buildtools.BuildToolUtils;
@@ -68,8 +68,7 @@ public class Gradle implements BuildFeature, DefaultFeature {
     private static final String GRADLE_PROPERTIES = "gradle.properties";
 
     @Override
-    @NonNull
-    public String getName() {
+    public @NonNull String getName() {
         return NAME;
     }
 

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/gradle/GradleBuild.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/gradle/GradleBuild.java
@@ -15,7 +15,8 @@
  */
 package io.micronaut.projectgen.core.buildtools.gradle;
 
-import io.micronaut.core.annotation.NonNull;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.projectgen.core.buildtools.dependencies.Coordinate;
 import io.micronaut.projectgen.core.buildtools.dependencies.DependencyCoordinate;
@@ -49,7 +50,7 @@ import io.micronaut.projectgen.core.template.substitutions;
  * @param repositories Repositories
  */
 @Builder
-public record GradleBuild(Coordinate coordinate,
+public record GradleBuild(@Nullable Coordinate coordinate,
                           GradleDsl dsl,
                           List<GradleDependency> dependencies,
                           List<GradlePlugin> plugins,
@@ -60,8 +61,7 @@ public record GradleBuild(Coordinate coordinate,
      *
      * @return Plugins
      */
-    @NonNull
-    public List<GradlePlugin> getPlugins() {
+    public @NonNull List<GradlePlugin> getPlugins() {
         return plugins.stream().filter(gradlePlugin -> gradlePlugin.getGradleFile() == GradleFile.BUILD).toList();
     }
 
@@ -69,8 +69,7 @@ public record GradleBuild(Coordinate coordinate,
      *
      * @return Settings Imports
      */
-    @NonNull
-    public List<String> getSettingsImports() {
+    public @NonNull List<String> getSettingsImports() {
         return plugins.stream().filter(gradlePlugin -> gradlePlugin.getGradleFile() == GradleFile.SETTINGS).map(GradlePlugin::getSettingsImports).flatMap(Collection::stream).toList();
     }
 
@@ -78,8 +77,7 @@ public record GradleBuild(Coordinate coordinate,
      *
      * @return Settings Plugins
      */
-    @NonNull
-    public List<GradlePlugin> getSettingsPlugins() {
+    public @NonNull List<GradlePlugin> getSettingsPlugins() {
         return plugins.stream().filter(gradlePlugin -> gradlePlugin.getGradleFile() == GradleFile.SETTINGS).collect(Collectors.toList());
     }
 
@@ -87,8 +85,7 @@ public record GradleBuild(Coordinate coordinate,
      *
      * @return substitutions rendered
      */
-    @NonNull
-    public String renderSubstitutions() {
+    public @NonNull String renderSubstitutions() {
         Set<Substitution> uniqueSubstitutions = new HashSet<>();
         dependencies
             .stream()
@@ -104,8 +101,7 @@ public record GradleBuild(Coordinate coordinate,
      *
      * @return extensions rendered
      */
-    @NonNull
-    public String renderExtensions() {
+    public @NonNull String renderExtensions() {
         List<Writable> extensions = plugins.stream()
             .map(GradlePlugin::getExtension)
             .filter(Objects::nonNull)
@@ -117,8 +113,7 @@ public record GradleBuild(Coordinate coordinate,
      *
      * @return settings extensions rendered
      */
-    @NonNull
-    public String renderSettingsExtensions() {
+    public @NonNull String renderSettingsExtensions() {
         return renderWritableExtensions(getSettingsExtensionsStream());
     }
 
@@ -137,8 +132,7 @@ public record GradleBuild(Coordinate coordinate,
      *
      * @return repositories rendered
      */
-    @NonNull
-    public String renderRepositories() {
+    public @NonNull String renderRepositories() {
         String result = WritableUtils.renderWritableList(repositories.stream()
             .map(Writable.class::cast)
             .toList(), 4);
@@ -153,8 +147,7 @@ public record GradleBuild(Coordinate coordinate,
      *
      * @return settings plugins management rendered
      */
-    @NonNull
-    public String renderSettingsPluginsManagement() {
+    public @NonNull String renderSettingsPluginsManagement() {
         List<GradleRepository> repos = getPluginsManagementRepositories();
         if (CollectionUtils.isEmpty(repos)) {
             return "";
@@ -173,8 +166,7 @@ public record GradleBuild(Coordinate coordinate,
      *
      * @return writable extensions rendered
      */
-    @NonNull
-    private String renderWritableExtensions(Stream<Writable> extensions) {
+    private @NonNull String renderWritableExtensions(Stream<Writable> extensions) {
         StringBuilder result = new StringBuilder();
         extensions
             .filter(Objects::nonNull)
@@ -197,8 +189,7 @@ public record GradleBuild(Coordinate coordinate,
      *
      * @return plugins imports
      */
-    @NonNull
-    public Set<String> getPluginsImports() {
+    public @NonNull Set<String> getPluginsImports() {
         Set<String> imports = new HashSet<>();
         for (GradlePlugin p : plugins) {
             Set<String> pluginImports = p.getBuildImports();

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/gradle/GradleBuildCreator.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/gradle/GradleBuildCreator.java
@@ -16,7 +16,7 @@
 package io.micronaut.projectgen.core.buildtools.gradle;
 
 import com.fizzed.rocker.RockerModel;
-import io.micronaut.core.annotation.NonNull;
+import org.jspecify.annotations.NonNull;
 import io.micronaut.core.order.OrderUtil;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.projectgen.core.buildtools.BuildTool;
@@ -42,6 +42,7 @@ public final class GradleBuildCreator {
     private GradleBuildCreator() {
     }
 
+    @SuppressWarnings("NullAway")
     public static RockerTemplate buildFileTemplate(GeneratorContext generatorContext, ModuleContext moduleContext, String module) {
         GradleBuild build = create(generatorContext, moduleContext, generatorContext.getOptions());
         BuildTool buildTool = generatorContext.getOptions().buildTools().stream().filter(bt ->  bt == BuildTool.GRADLE).findFirst().orElseThrow();
@@ -56,15 +57,13 @@ public final class GradleBuildCreator {
             : module + "/" + buildFileName, rockerModel);
     }
 
-    @NonNull
-    public static GradleBuild create(@NonNull GeneratorContext generatorContext,
+    public static @NonNull GradleBuild create(@NonNull GeneratorContext generatorContext,
                                      @NonNull ModuleContext module,
                                      Options options) {
         return create(generatorContext, module, options, DEFAULT_USER_VERSION_CATALOGUE);
     }
 
-    @NonNull
-    public static GradleBuild create(@NonNull GeneratorContext generatorContext,
+    public static @NonNull GradleBuild create(@NonNull GeneratorContext generatorContext,
                               @NonNull ModuleContext module,
                               Options options, boolean useVersionCatalogue) {
         if (!OptionUtils.hasGradleBuildTool(generatorContext.getOptions())) {
@@ -93,8 +92,7 @@ public final class GradleBuildCreator {
      * @param repositories Repositories
      * @return Gradle Repositories
      */
-    @NonNull
-    private static List<GradleRepository> getRepositories(@NonNull Options options,
+    private static @NonNull List<GradleRepository> getRepositories(@NonNull Options options,
                                                      Collection<Repository> repositories) {
         BuildTool buildTool = options.buildTools().stream()
             .filter(bt -> bt == BuildTool.GRADLE).findFirst().orElseThrow();

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/gradle/GradleConfiguration.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/gradle/GradleConfiguration.java
@@ -15,8 +15,8 @@
  */
 package io.micronaut.projectgen.core.buildtools.gradle;
 
-import io.micronaut.core.annotation.NonNull;
-import io.micronaut.core.annotation.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import io.micronaut.core.order.Ordered;
 import io.micronaut.projectgen.core.buildtools.Phase;
 import io.micronaut.projectgen.core.buildtools.Scope;
@@ -72,8 +72,7 @@ public enum GradleConfiguration implements Ordered {
         return order;
     }
 
-    @NonNull
-    public static Optional<GradleConfiguration> of(@NonNull Scope scope,
+    public static @NonNull Optional<GradleConfiguration> of(@NonNull Scope scope,
                                                    @NonNull Language language,
                                                    @NonNull TestFramework testFramework,
                                                    @Nullable GeneratorContext generatorContext) {
@@ -153,14 +152,14 @@ public enum GradleConfiguration implements Ordered {
         return Optional.empty();
     }
 
-    private static GradleConfiguration kotlinAnnotationProcessor(GeneratorContext generatorContext) {
+    private static GradleConfiguration kotlinAnnotationProcessor(@Nullable GeneratorContext generatorContext) {
         if (generatorContext == null || generatorContext.isFeaturePresent(KotlinSymbolProcessingFeature.class)) {
             return GradleConfiguration.KSP;
         }
         return GradleConfiguration.KAPT;
     }
 
-    private static GradleConfiguration kotlinTestAnnotationProcessor(GeneratorContext generatorContext) {
+    private static GradleConfiguration kotlinTestAnnotationProcessor(@Nullable GeneratorContext generatorContext) {
         if (generatorContext == null || generatorContext.isFeaturePresent(KotlinSymbolProcessingFeature.class)) {
             return GradleConfiguration.TEST_KSP;
         }

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/gradle/GradleDependency.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/gradle/GradleDependency.java
@@ -74,8 +74,8 @@ public class GradleDependency extends DependencyCoordinate {
                             @Nullable String comment) {
         super(dependency);
         Scope scope = Objects.requireNonNull(dependency.getScope(), "Dependency scope must be set");
-        Language language = options.language() == null ? Language.JAVA : options.language();
-        TestFramework testFramework = options.testFramework() == null ? TestFramework.DEFAULT_OPTION : options.testFramework();
+        Language language = options.language();
+        TestFramework testFramework = options.testFramework();
         gradleConfiguration = GradleConfiguration.of(
             scope,
             language,
@@ -205,7 +205,7 @@ public class GradleDependency extends DependencyCoordinate {
     public static @NonNull List<GradleDependency> listOf(GeneratorContext generatorContext, DependencyContext dependencyContext, Options options, boolean useVersionCatalogue) {
         BuildTool buildTool = options.buildTools().stream()
             .filter(bt -> bt == BuildTool.GRADLE).findFirst().orElseThrow();
-        Language language = options.language() == null ? Language.JAVA : options.language();
+        Language language = options.language();
         return dependencyContext.removeDuplicates(dependencyContext.getDependenciesByBuildTool(BuildTool.GRADLE), language, buildTool)
             .stream()
             .map(dep -> new GradleDependency(dep, options, generatorContext, useVersionCatalogue, dep.getProject(), dep.getComment()))

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/gradle/GradleDependency.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/gradle/GradleDependency.java
@@ -15,8 +15,8 @@
  */
 package io.micronaut.projectgen.core.buildtools.gradle;
 
-import io.micronaut.core.annotation.NonNull;
-import io.micronaut.core.annotation.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import io.micronaut.core.order.OrderUtil;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.core.util.StringUtils;
@@ -26,13 +26,17 @@ import io.micronaut.projectgen.core.buildtools.dependencies.Dependency;
 import io.micronaut.projectgen.core.buildtools.dependencies.DependencyContext;
 import io.micronaut.projectgen.core.buildtools.dependencies.DependencyCoordinate;
 import io.micronaut.projectgen.core.generator.GeneratorContext;
+import io.micronaut.projectgen.core.options.Language;
 import io.micronaut.projectgen.core.options.Options;
+import io.micronaut.projectgen.core.options.TestFramework;
 
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import io.micronaut.projectgen.core.buildtools.Scope;
+
 import static io.micronaut.core.util.CollectionUtils.isNotEmpty;
 
 /**
@@ -54,11 +58,12 @@ public class GradleDependency extends DependencyCoordinate {
 
     private final Boolean isKotlinDSL;
 
-    @NonNull
-    private final GradleConfiguration gradleConfiguration;
+    private final @NonNull GradleConfiguration gradleConfiguration;
 
     private final boolean useVersionCatalogue;
+    @Nullable
     private final String project;
+    @Nullable
     private final String comment;
 
     public GradleDependency(@NonNull Dependency dependency,
@@ -68,13 +73,16 @@ public class GradleDependency extends DependencyCoordinate {
                             @Nullable String project,
                             @Nullable String comment) {
         super(dependency);
+        Scope scope = Objects.requireNonNull(dependency.getScope(), "Dependency scope must be set");
+        Language language = options.language() == null ? Language.JAVA : options.language();
+        TestFramework testFramework = options.testFramework() == null ? TestFramework.DEFAULT_OPTION : options.testFramework();
         gradleConfiguration = GradleConfiguration.of(
-            dependency.getScope(),
-            options.language(),
-            options.testFramework(),
+            scope,
+            language,
+            testFramework,
             generatorContext
         ).orElseThrow(() ->
-            new IllegalArgumentException("Cannot map the dependency scope: [%s] to a Gradle specific scope".formatted(dependency.getScope())));
+            new IllegalArgumentException("Cannot map the dependency scope: [%s] to a Gradle specific scope".formatted(scope)));
         isKotlinDSL = generatorContext.getOptions().buildTools().stream()
             .anyMatch(bt -> bt == BuildTool.GRADLE && options.gradleDsl() != null && options.gradleDsl() == GradleDsl.KOTLIN);
         this.useVersionCatalogue = useVersionCatalogue;
@@ -86,8 +94,7 @@ public class GradleDependency extends DependencyCoordinate {
      *
      * @return Gradle Configuration
      */
-    @NonNull
-    public GradleConfiguration getConfiguration() {
+    public @NonNull GradleConfiguration getConfiguration() {
         return gradleConfiguration;
     }
 
@@ -118,8 +125,7 @@ public class GradleDependency extends DependencyCoordinate {
      *
      * @return snippet representation
      */
-    @NonNull
-    public String toSnippet() {
+    public @NonNull String toSnippet() {
         String snippet = "";
         if (StringUtils.isNotEmpty(comment)) {
             snippet += "/* " + comment + " */\n    ";
@@ -162,8 +168,7 @@ public class GradleDependency extends DependencyCoordinate {
      *
      * @return Maven Coordinate surrounded by double quotes
      */
-    @NonNull
-    public String mavenCoordinate() {
+    public @NonNull String mavenCoordinate() {
         List<String> parts = new ArrayList<>();
         if (getGroupId() != null) {
             parts.add(getGroupId());
@@ -189,19 +194,19 @@ public class GradleDependency extends DependencyCoordinate {
      *
      * @return version catalogue
      */
-    @NonNull
-    public Optional<String> versionCatalog() {
-        if (!getGroupId().startsWith("io.micronaut")) {
+    public @NonNull Optional<String> versionCatalog() {
+        String groupId = getGroupId();
+        if (groupId == null || !groupId.startsWith("io.micronaut")) {
             return Optional.empty();
         }
         return Optional.of("mn." + getArtifactId().replace("-", "."));
     }
 
-    @NonNull
-    public static List<GradleDependency> listOf(GeneratorContext generatorContext, DependencyContext dependencyContext, Options options, boolean useVersionCatalogue) {
+    public static @NonNull List<GradleDependency> listOf(GeneratorContext generatorContext, DependencyContext dependencyContext, Options options, boolean useVersionCatalogue) {
         BuildTool buildTool = options.buildTools().stream()
             .filter(bt -> bt == BuildTool.GRADLE).findFirst().orElseThrow();
-        return dependencyContext.removeDuplicates(dependencyContext.getDependenciesByBuildTool(BuildTool.GRADLE), options.language(), buildTool)
+        Language language = options.language() == null ? Language.JAVA : options.language();
+        return dependencyContext.removeDuplicates(dependencyContext.getDependenciesByBuildTool(BuildTool.GRADLE), language, buildTool)
             .stream()
             .map(dep -> new GradleDependency(dep, options, generatorContext, useVersionCatalogue, dep.getProject(), dep.getComment()))
             .sorted(GradleDependency.COMPARATOR)

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/gradle/GradlePlugin.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/gradle/GradlePlugin.java
@@ -15,8 +15,8 @@
  */
 package io.micronaut.projectgen.core.buildtools.gradle;
 
-import io.micronaut.core.annotation.NonNull;
-import io.micronaut.core.annotation.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.projectgen.core.buildtools.BuildPlugin;
 import io.micronaut.projectgen.core.buildtools.BuildTool;
@@ -42,6 +42,7 @@ public class GradlePlugin implements BuildPlugin {
     public static final int ORDER = -10;
 
     private final GradleFile gradleFile;
+    @Nullable
     private final String id;
 
     /**
@@ -50,12 +51,18 @@ public class GradlePlugin implements BuildPlugin {
     @Nullable
     private final String alias; // Notation coming from a version catalgoue
 
+    @Nullable
     private final String version;
+    @Nullable
     private final Boolean apply;
+    @Nullable
     private final String artifactId;
+    @Nullable
     private final Writable extension;
+    @Nullable
     private final Writable settingsExtension;
     private final boolean requiresLookup;
+    @Nullable
     private final List<GradleRepository> pluginsManagementRepositories;
     private final Set<String> buildImports;
     private final Set<String> settingsImports;
@@ -70,7 +77,7 @@ public class GradlePlugin implements BuildPlugin {
                         @Nullable String artifactId,
                         @Nullable Writable extension,
                         @Nullable Writable settingsExtension,
-                        List<GradleRepository> pluginsManagementRepositories,
+                        @Nullable List<GradleRepository> pluginsManagementRepositories,
                         boolean requiresLookup,
                         int order,
                         Set<String> buildImports) {
@@ -116,7 +123,7 @@ public class GradlePlugin implements BuildPlugin {
                         @Nullable String artifactId,
                         @Nullable Writable extension,
                         @Nullable Writable settingsExtension,
-                        List<GradleRepository> pluginsManagementRepositories,
+                        @Nullable List<GradleRepository> pluginsManagementRepositories,
                         boolean requiresLookup,
                         int order,
                         Set<String> buildImports,
@@ -140,6 +147,7 @@ public class GradlePlugin implements BuildPlugin {
      *
      * @return apply
      */
+    @Nullable
     public Boolean getApply() {
         return apply;
     }
@@ -180,8 +188,7 @@ public class GradlePlugin implements BuildPlugin {
      *
      * @return Gradle file
      */
-    @NonNull
-    public GradleFile getGradleFile() {
+    public @NonNull GradleFile getGradleFile() {
         return gradleFile;
     }
 
@@ -189,7 +196,7 @@ public class GradlePlugin implements BuildPlugin {
      *
      * @return plugin id
      */
-    @NonNull
+    @Nullable
     public String getId() {
         return id;
     }
@@ -213,8 +220,7 @@ public class GradlePlugin implements BuildPlugin {
     }
 
     @Override
-    @NonNull
-    public BuildTool getBuildTool() {
+    public @NonNull BuildTool getBuildTool() {
         return BuildTool.GRADLE;
     }
 
@@ -237,8 +243,7 @@ public class GradlePlugin implements BuildPlugin {
      *
      * @return Plugins management repositories
      */
-    @NonNull
-    public List<GradleRepository> getPluginsManagementRepositories() {
+    public @NonNull List<GradleRepository> getPluginsManagementRepositories() {
         return CollectionUtils.isEmpty(pluginsManagementRepositories) ?
             Collections.emptyList() : pluginsManagementRepositories;
     }
@@ -255,8 +260,9 @@ public class GradlePlugin implements BuildPlugin {
 
     @Override
     public BuildPlugin resolved(CoordinateResolver coordinateResolver) {
-        Coordinate coordinate = coordinateResolver.resolve(artifactId)
-            .orElseThrow(() -> new LookupFailedException(artifactId));
+        String lookupArtifactId = Objects.requireNonNull(artifactId, "The artifact id must be set");
+        Coordinate coordinate = coordinateResolver.resolve(lookupArtifactId)
+            .orElseThrow(() -> new LookupFailedException(lookupArtifactId));
         return new GradlePlugin(gradleFile,
             id,
             coordinate.getVersion(),
@@ -281,7 +287,7 @@ public class GradlePlugin implements BuildPlugin {
             return false;
         }
         GradlePlugin that = (GradlePlugin) o;
-        return id.equals(that.id);
+        return Objects.equals(id, that.id);
     }
 
     @Override
@@ -303,13 +309,21 @@ public class GradlePlugin implements BuildPlugin {
     public static final class Builder {
 
         private GradleFile gradleFile = GradleFile.BUILD;
+        @Nullable
         private String id;
+        @Nullable
         private String artifactId;
+        @Nullable
         private Boolean apply;
+        @Nullable
         private String version;
+        @Nullable
         private String alias;
+        @Nullable
         private Writable extension;
+        @Nullable
         private Writable settingsExtension;
+        @Nullable
         private List<GradleRepository> pluginsManagementRepositories;
         private boolean requiresLookup;
         private int order;
@@ -318,80 +332,67 @@ public class GradlePlugin implements BuildPlugin {
 
         private Builder() { }
 
-        @NonNull
-        public GradlePlugin.Builder gradleFile(@NonNull GradleFile file) {
+        public GradlePlugin.@NonNull Builder gradleFile(@NonNull GradleFile file) {
             this.gradleFile = file;
             return this;
         }
 
-        @NonNull
-        public GradlePlugin.Builder id(@NonNull String id) {
+        public GradlePlugin.@NonNull Builder id(@NonNull String id) {
             this.id = id;
             return this;
         }
 
-        @NonNull
-        public GradlePlugin.Builder alias(@NonNull String alias) {
+        public GradlePlugin.@NonNull Builder alias(@NonNull String alias) {
             this.alias = alias;
             return this;
         }
 
-        @NonNull
-        public GradlePlugin.Builder buildImports(String... imports) {
+        public GradlePlugin.@NonNull Builder buildImports(String... imports) {
             this.buildImports.addAll(Arrays.asList(imports));
             return this;
         }
 
-        @NonNull
-        public GradlePlugin.Builder settingsImports(String... imports) {
+        public GradlePlugin.@NonNull Builder settingsImports(String... imports) {
             this.settingsImports.addAll(Arrays.asList(imports));
             return this;
         }
 
-        @NonNull
-        public GradlePlugin.Builder lookupArtifactId(@NonNull String artifactId) {
+        public GradlePlugin.@NonNull Builder lookupArtifactId(@NonNull String artifactId) {
             this.artifactId = artifactId;
             this.requiresLookup = true;
             return this;
         }
 
-        @NonNull
-        public Optional<String> getArtifiactId()  {
+        public @NonNull Optional<String> getArtifiactId() {
             return Optional.ofNullable(artifactId);
         }
 
-        @NonNull
-        public GradlePlugin.Builder version(@Nullable String version) {
+        public GradlePlugin.@NonNull Builder version(@Nullable String version) {
             this.version = version;
             return this;
         }
 
-        @NonNull
-        public GradlePlugin.Builder extension(@Nullable Writable extension) {
+        public GradlePlugin.@NonNull Builder extension(@Nullable Writable extension) {
             this.extension = extension;
             return this;
         }
 
-        @NonNull
-        public GradlePlugin.Builder extension(@Nullable String extension) {
-            this.extension = new StringWritable(extension);
+        public GradlePlugin.@NonNull Builder extension(@Nullable String extension) {
+            this.extension = extension == null ? null : new StringWritable(extension);
             return this;
         }
 
-        @NonNull
-        public GradlePlugin.Builder settingsExtension(@Nullable Writable settingsExtension) {
+        public GradlePlugin.@NonNull Builder settingsExtension(@Nullable Writable settingsExtension) {
             this.settingsExtension = settingsExtension;
             return this;
         }
 
-        @NonNull
-        public GradlePlugin.Builder order(int order) {
+        public GradlePlugin.@NonNull Builder order(int order) {
             this.order = order;
             return this;
         }
 
-        @NonNull
-        public GradlePlugin.Builder pluginsManagementRepository(GradleRepository repo) {
+        public GradlePlugin.@NonNull Builder pluginsManagementRepository(GradleRepository repo) {
             if (this.pluginsManagementRepositories == null) {
                 this.pluginsManagementRepositories = new ArrayList<>();
             }

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/gradle/GradleRepository.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/gradle/GradleRepository.java
@@ -15,7 +15,7 @@
  */
 package io.micronaut.projectgen.core.buildtools.gradle;
 
-import io.micronaut.core.annotation.NonNull;
+import org.jspecify.annotations.NonNull;
 import io.micronaut.projectgen.core.buildtools.MavenCentral;
 import io.micronaut.projectgen.core.buildtools.MavenLocal;
 import io.micronaut.projectgen.core.buildtools.Repository;
@@ -116,8 +116,7 @@ public class GradleRepository implements Writable {
         return "maven { url \"" + getUrl() + "\"" + (isSnapshot ? "\n    mavenContent { snapshotsOnly() }\n" : " ") + "}\n";
     }
 
-    @NonNull
-    public static List<GradleRepository> listOf(GradleDsl gradleDsl, Collection<Repository> repositories) {
+    public static @NonNull List<GradleRepository> listOf(GradleDsl gradleDsl, Collection<Repository> repositories) {
         return repositories.stream()
             .map(it -> {
                 if (it instanceof MavenCentral) {
@@ -136,8 +135,7 @@ public class GradleRepository implements Writable {
      * @param repository Repository
      * @return Gradle Repository
      */
-    @NonNull
-    public static GradleRepository of(GradleDsl gradleDsl, Repository repository) {
+    public static @NonNull GradleRepository of(GradleDsl gradleDsl, Repository repository) {
         return new GradleRepository(gradleDsl, repository.getUrl(), repository.isSnapshot());
     }
 

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/maven/Maven.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/maven/Maven.java
@@ -17,7 +17,7 @@ package io.micronaut.projectgen.core.buildtools.maven;
 
 import com.fizzed.rocker.RockerModel;
 import io.micronaut.context.annotation.Requires;
-import io.micronaut.core.annotation.NonNull;
+import org.jspecify.annotations.NonNull;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.projectgen.core.feature.BuildFeature;
 import io.micronaut.projectgen.core.feature.DefaultFeature;
@@ -58,8 +58,7 @@ public class Maven implements BuildFeature, DefaultFeature {
     }
 
     @Override
-    @NonNull
-    public String getName() {
+    public @NonNull String getName() {
         return "maven";
     }
 

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/maven/MavenBuild.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/maven/MavenBuild.java
@@ -15,8 +15,8 @@
  */
 package io.micronaut.projectgen.core.buildtools.maven;
 
-import io.micronaut.core.annotation.NonNull;
-import io.micronaut.core.annotation.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import io.micronaut.projectgen.core.buildtools.Property;
 import io.micronaut.projectgen.core.buildtools.dependencies.Coordinate;
 import io.micronaut.projectgen.core.buildtools.dependencies.DependencyCoordinate;
@@ -47,13 +47,13 @@ import java.util.Objects;
  * @param repositories repositories
  */
 @Builder
-public record MavenBuild(String name,
-                         String description,
-                         Coordinate coordinate,
+public record MavenBuild(@Nullable String name,
+                         @Nullable String description,
+                         @Nullable Coordinate coordinate,
                          @Nullable String packaging,
-                         ParentPom parentPom,
-                         MavenCombineAttribute annotationProcessorCombineAttribute,
-                         MavenCombineAttribute testAnnotationProcessorCombineAttribute,
+                         @Nullable ParentPom parentPom,
+                         @Nullable MavenCombineAttribute annotationProcessorCombineAttribute,
+                         @Nullable MavenCombineAttribute testAnnotationProcessorCombineAttribute,
                          List<DependencyCoordinate> testAnnotationProcessors,
                          List<DependencyCoordinate> annotationProcessors,
                          List<MavenDependency> dependencies,
@@ -66,8 +66,7 @@ public record MavenBuild(String name,
      * @param indentationSpaces Indentation Spaces
      * @return rendered string
      */
-    @NonNull
-    public String renderRepositories(int indentationSpaces) {
+    public @NonNull String renderRepositories(int indentationSpaces) {
         return WritableUtils.renderWritableList(this.repositories.stream()
             .map(Writable.class::cast)
             .toList(), indentationSpaces);
@@ -78,8 +77,7 @@ public record MavenBuild(String name,
      * @param indentationSpaces Indentation Spaces
      * @return rendered string
      */
-    @NonNull
-    public String renderPlugins(int indentationSpaces) {
+    public @NonNull String renderPlugins(int indentationSpaces) {
         List<Writable> writableList = plugins.stream()
             .map(MavenPlugin::getExtension)
             .filter(Objects::nonNull)
@@ -92,8 +90,7 @@ public record MavenBuild(String name,
      * @param indentationSpaces Indentation Spaces
      * @return rendered string
      */
-    @NonNull
-    public String renderProfiles(int indentationSpaces) {
+    public @NonNull String renderProfiles(int indentationSpaces) {
         List<Writable> writableList = profiles.stream()
             .map(Profile::getExtension)
             .filter(Objects::nonNull)
@@ -101,14 +98,12 @@ public record MavenBuild(String name,
         return WritableUtils.renderWritableList(writableList, indentationSpaces);
     }
 
-
     /**
      *
      * @param pom pom
      * @return Dependencies
      */
-    @NonNull
-    public List<MavenDependency> getDependencies(boolean pom) {
+    public @NonNull List<MavenDependency> getDependencies(boolean pom) {
         return dependencies
             .stream()
             .filter(it -> it.isPom() == pom)

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/maven/MavenBuildCreator.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/maven/MavenBuildCreator.java
@@ -15,10 +15,11 @@
  */
 package io.micronaut.projectgen.core.buildtools.maven;
 
-import io.micronaut.core.annotation.NonNull;
+import org.jspecify.annotations.NonNull;
 import io.micronaut.core.order.OrderUtil;
 import io.micronaut.projectgen.core.buildtools.BuildProperties;
 import io.micronaut.projectgen.core.generator.ModuleContext;
+import io.micronaut.projectgen.core.options.Language;
 import io.micronaut.projectgen.core.options.Options;
 import jakarta.inject.Singleton;
 
@@ -35,11 +36,11 @@ public class MavenBuildCreator {
      * @param options Options
      * @return Maven Build
      */
-    @NonNull
-    public MavenBuild create(ModuleContext module,
+    public @NonNull MavenBuild create(ModuleContext module,
                              Options options) {
+        Language language = options.language() == null ? Language.JAVA : options.language();
         List<MavenDependency> dependencies = MavenDependency.listOf(module.dependencyContext(),
-            options.language());
+            language);
         BuildProperties buildProperties = module.buildProperties();
 
 
@@ -50,22 +51,21 @@ public class MavenBuildCreator {
             .sorted(OrderUtil.COMPARATOR)
             .toList();
 
-        MavenCompilerPluginAnnotationProcessors ann = MavenCompilerPluginAnnotationProcessors.of(module, options.language());
-        return MavenBuildBuilder.builder()
-            .parentPom(module.moduleAttributes().getParentPom())
-            .packaging(module.moduleAttributes().getPackaging())
-            .coordinate(module.moduleAttributes().getCoordinate())
-            .name(module.moduleAttributes().getName())
-            .description(module.moduleAttributes().getDescription())
-            .repositories(MavenRepository.listOf(module.repositories()))
-            .plugins(plugins)
-            .properties(buildProperties.getProperties())
-            .annotationProcessorCombineAttribute(ann.combineAttribute())
-            .testAnnotationProcessorCombineAttribute(ann.testCombineAttribute())
-            .profiles(module.profiles())
-            .dependencies(dependencies)
-            .annotationProcessors(ann.annotationProcessors())
-            .testAnnotationProcessors(ann.testAnnotationProcessors())
-            .build();
+        MavenCompilerPluginAnnotationProcessors ann = MavenCompilerPluginAnnotationProcessors.of(module, language);
+        return new MavenBuild(
+            module.moduleAttributes().getName(),
+            module.moduleAttributes().getDescription(),
+            module.moduleAttributes().getCoordinate(),
+            module.moduleAttributes().getPackaging(),
+            module.moduleAttributes().getParentPom(),
+            ann.combineAttribute(),
+            ann.testCombineAttribute(),
+            ann.testAnnotationProcessors(),
+            ann.annotationProcessors(),
+            dependencies,
+            plugins,
+            buildProperties.getProperties(),
+            module.profiles(),
+            MavenRepository.listOf(module.repositories()));
     }
 }

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/maven/MavenBuildCreator.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/maven/MavenBuildCreator.java
@@ -38,7 +38,7 @@ public class MavenBuildCreator {
      */
     public @NonNull MavenBuild create(ModuleContext module,
                              Options options) {
-        Language language = options.language() == null ? Language.JAVA : options.language();
+        Language language = options.language();
         List<MavenDependency> dependencies = MavenDependency.listOf(module.dependencyContext(),
             language);
         BuildProperties buildProperties = module.buildProperties();

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/maven/MavenCompilerPluginAnnotationProcessors.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/maven/MavenCompilerPluginAnnotationProcessors.java
@@ -16,6 +16,7 @@
 package io.micronaut.projectgen.core.buildtools.maven;
 
 import io.micronaut.projectgen.core.buildtools.Phase;
+import io.micronaut.projectgen.core.buildtools.Scope;
 import io.micronaut.projectgen.core.buildtools.Source;
 import io.micronaut.projectgen.core.buildtools.dependencies.Coordinate;
 import io.micronaut.projectgen.core.buildtools.dependencies.Dependency;
@@ -46,8 +47,9 @@ public record MavenCompilerPluginAnnotationProcessors(
         MavenCombineAttribute testCombineAttribute = combineAttribute;
 
         for (Dependency dependency : module.getDependencies()) {
-            if (dependency.getScope().getPhases().contains(Phase.ANNOTATION_PROCESSING)) {
-                if (dependency.getScope().getSource() == Source.MAIN && language != Language.GROOVY) {
+            Scope scope = dependency.getScope();
+            if (scope != null && scope.getPhases().contains(Phase.ANNOTATION_PROCESSING)) {
+                if (scope.getSource() == Source.MAIN && language != Language.GROOVY) {
                     // Don't add these for Groovy projects: it results in multiple dependencies.
                     // DependencyContext has already resolved Groovy annotation processors as dependencies
                     annotationProcessors.add(new DependencyCoordinate(dependency, true));
@@ -55,7 +57,7 @@ public record MavenCompilerPluginAnnotationProcessors(
                         combineAttribute = MavenCombineAttribute.OVERRIDE;
                     }
                 }
-                if (dependency.getScope().getSource() == Source.TEST) {
+                if (scope.getSource() == Source.TEST) {
                     testAnnotationProcessors.add(new DependencyCoordinate(dependency, true));
                     if (dependency.isAnnotationProcessorPriority()) {
                         testCombineAttribute = MavenCombineAttribute.OVERRIDE;
@@ -76,4 +78,3 @@ public record MavenCompilerPluginAnnotationProcessors(
         return isKotlin ? MavenCombineAttribute.OVERRIDE : MavenCombineAttribute.APPEND;
     }
 }
-

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/maven/MavenCompilerPluginUtils.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/maven/MavenCompilerPluginUtils.java
@@ -28,6 +28,7 @@ public final class MavenCompilerPluginUtils {
     private MavenCompilerPluginUtils() {
     }
 
+    @SuppressWarnings("NullAway")
     public static Optional<MavenPlugin> mavenCompilerPlugin(GeneratorContext generatorContext,
                                                             ModuleContext module,
                                                             MavenCompilerPluginConfiguration configuration) {

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/maven/MavenDependency.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/maven/MavenDependency.java
@@ -15,16 +15,18 @@
  */
 package io.micronaut.projectgen.core.buildtools.maven;
 
-import io.micronaut.core.annotation.NonNull;
-import io.micronaut.core.annotation.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import io.micronaut.core.order.OrderUtil;
 import io.micronaut.projectgen.core.buildtools.BuildTool;
+import io.micronaut.projectgen.core.buildtools.Scope;
 import io.micronaut.projectgen.core.buildtools.dependencies.Dependency;
 import io.micronaut.projectgen.core.buildtools.dependencies.DependencyContext;
 import io.micronaut.projectgen.core.buildtools.dependencies.DependencyCoordinate;
 import io.micronaut.projectgen.core.options.Language;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 
 /**
  *
@@ -53,7 +55,8 @@ public class MavenDependency extends DependencyCoordinate {
         if (isPom()) {
             mavenScope = MavenScope.IMPORT;
         } else {
-            mavenScope = MavenScope.of(dependency.getScope(), language).orElse(null);
+            Scope scope = dependency.getScope();
+            mavenScope = scope == null ? null : MavenScope.of(scope, language).orElse(null);
         }
     }
 
@@ -86,12 +89,11 @@ public class MavenDependency extends DependencyCoordinate {
     @Override
     public int hashCode() {
         int result = super.hashCode();
-        result = 31 * result + mavenScope.hashCode();
+        result = 31 * result + Objects.hashCode(mavenScope);
         return result;
     }
 
-    @NonNull
-    public static List<MavenDependency> listOf(@NonNull DependencyContext dependencyContext, Language language) {
+    public static @NonNull List<MavenDependency> listOf(@NonNull DependencyContext dependencyContext, Language language) {
         return dependencyContext.removeDuplicates(dependencyContext.getDependenciesByBuildTool(BuildTool.MAVEN), language, BuildTool.MAVEN)
             .stream()
             .map(dep -> new MavenDependency(dep, language))

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/maven/MavenPlugin.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/maven/MavenPlugin.java
@@ -139,32 +139,32 @@ public class MavenPlugin implements BuildPlugin {
         private Builder() {
         }
 
-        public MavenPlugin.Builder extension(@Nullable String extension) {
+        public MavenPlugin.@NonNull Builder extension(@Nullable String extension) {
             this.extension = extension == null ? null : new StringWritable(extension);
             return this;
         }
 
-        public MavenPlugin.Builder extension(@Nullable Writable extension) {
+        public MavenPlugin.@NonNull Builder extension(@Nullable Writable extension) {
             this.extension = extension;
             return this;
         }
 
-        public MavenPlugin.Builder order(int order) {
+        public MavenPlugin.@NonNull Builder order(int order) {
             this.order = order;
             return this;
         }
 
-        public MavenPlugin.Builder artifactId(String artifactId) {
+        public MavenPlugin.@NonNull Builder artifactId(String artifactId) {
             this.artifactId = artifactId;
             return this;
         }
 
-        public MavenPlugin.Builder groupId(String groupId) {
+        public MavenPlugin.@NonNull Builder groupId(String groupId) {
             this.groupId = groupId;
             return this;
         }
 
-        public MavenPlugin.Builder version(String version) {
+        public MavenPlugin.@NonNull Builder version(String version) {
             this.version = version;
             return this;
         }

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/maven/MavenPlugin.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/maven/MavenPlugin.java
@@ -15,8 +15,8 @@
  */
 package io.micronaut.projectgen.core.buildtools.maven;
 
-import io.micronaut.core.annotation.NonNull;
-import io.micronaut.core.annotation.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import io.micronaut.projectgen.core.buildtools.BuildPlugin;
 import io.micronaut.projectgen.core.buildtools.BuildTool;
 import io.micronaut.projectgen.core.buildtools.dependencies.CoordinateResolver;
@@ -28,16 +28,19 @@ import java.util.Objects;
  * Maven Plugin.
  */
 public class MavenPlugin implements BuildPlugin {
+    @Nullable
     private final String groupId;
     private final String artifactId;
+    @Nullable
     private final String version;
+    @Nullable
     private final Writable extension;
     private final int order;
 
-    public MavenPlugin(String groupId,
+    public MavenPlugin(@Nullable String groupId,
                        String artifactId,
-                       String version,
-                       Writable extension, int order) {
+                       @Nullable String version,
+                       @Nullable Writable extension, int order) {
         this.groupId = groupId;
         this.artifactId = artifactId;
         this.version = version;
@@ -80,9 +83,8 @@ public class MavenPlugin implements BuildPlugin {
         return new Builder();
     }
 
-    @NonNull
     @Override
-    public BuildTool getBuildTool() {
+    public @NonNull BuildTool getBuildTool() {
         return BuildTool.MAVEN;
     }
 
@@ -124,40 +126,39 @@ public class MavenPlugin implements BuildPlugin {
      */
     public static final class Builder {
 
+        @Nullable
         private String artifactId;
+        @Nullable
         private String groupId;
+        @Nullable
         private String version;
+        @Nullable
         private Writable extension;
         private int order;
 
         private Builder() {
         }
 
-        @NonNull
         public MavenPlugin.Builder extension(@Nullable String extension) {
-            this.extension = new StringWritable(extension);
+            this.extension = extension == null ? null : new StringWritable(extension);
             return this;
         }
 
-        @NonNull
         public MavenPlugin.Builder extension(@Nullable Writable extension) {
             this.extension = extension;
             return this;
         }
 
-        @NonNull
         public MavenPlugin.Builder order(int order) {
             this.order = order;
             return this;
         }
 
-        @NonNull
         public MavenPlugin.Builder artifactId(String artifactId) {
             this.artifactId = artifactId;
             return this;
         }
 
-        @NonNull
         public MavenPlugin.Builder groupId(String groupId) {
             this.groupId = groupId;
             return this;
@@ -168,19 +169,18 @@ public class MavenPlugin implements BuildPlugin {
             return this;
         }
 
-        @NonNull
-        public MavenPlugin build() {
-            Objects.requireNonNull(artifactId, "The artifact id must be set");
+        public @NonNull MavenPlugin build() {
+            String pluginArtifactId = Objects.requireNonNull(artifactId, "The artifact id must be set");
             if (groupId != null && extension == null) {
                 extension = new StringWritable(
 "<plugin>\n" +
     "  <groupId>" + groupId + "</groupId>\n" +
-    "  <artifactId>" + artifactId + "</artifactId>\n" +
+    "  <artifactId>" + pluginArtifactId + "</artifactId>\n" +
     (version != null ? "  <version>" + version + "</version>\n" : "") +
     "</plugin>\n");
             }
-            Objects.requireNonNull(extension, "Maven plugins require an extension or a groupId");
-            return new MavenPlugin(groupId, artifactId, version, extension, order);
+            Writable pluginExtension = Objects.requireNonNull(extension, "Maven plugins require an extension or a groupId");
+            return new MavenPlugin(groupId, pluginArtifactId, version, pluginExtension, order);
         }
     }
 }

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/maven/MavenRepository.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/maven/MavenRepository.java
@@ -16,7 +16,7 @@
 package io.micronaut.projectgen.core.buildtools.maven;
 
 import com.fizzed.rocker.RockerModel;
-import io.micronaut.core.annotation.NonNull;
+import org.jspecify.annotations.NonNull;
 import io.micronaut.projectgen.core.buildtools.MavenCentral;
 import io.micronaut.projectgen.core.buildtools.Repository;
 import io.micronaut.projectgen.core.rocker.RockerWritable;
@@ -38,8 +38,7 @@ public class MavenRepository extends RockerWritable {
         this(mavenRepository.template(id, url, snapshot));
     }
 
-    @NonNull
-    public static List<MavenRepository> listOf(Collection<Repository> repositories) {
+    public static @NonNull List<MavenRepository> listOf(Collection<Repository> repositories) {
         return repositories.stream()
             .filter(repo -> !repo.getId().equals(MavenCentral.MAVEN_CENTRAL_ID))
             .map(it -> new MavenRepository(it.getId(), it.getUrl(), it.isSnapshot()))

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/maven/MavenScope.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/maven/MavenScope.java
@@ -15,7 +15,7 @@
  */
 package io.micronaut.projectgen.core.buildtools.maven;
 
-import io.micronaut.core.annotation.NonNull;
+import org.jspecify.annotations.NonNull;
 import io.micronaut.core.order.Ordered;
 import io.micronaut.projectgen.core.buildtools.Phase;
 import io.micronaut.projectgen.core.buildtools.Scope;
@@ -54,8 +54,7 @@ public enum MavenScope implements Ordered {
         return this.order;
     }
 
-    @NonNull
-    public Optional<Scope> toScope() {
+    public @NonNull Optional<Scope> toScope() {
         switch (this) {
             case COMPILE -> {
                 return Optional.of(Scope.COMPILE);
@@ -72,9 +71,10 @@ public enum MavenScope implements Ordered {
             case SYSTEM, IMPORT -> {
                 return Optional.empty();
             }
-            default -> Optional.empty();
+            default -> {
+                return Optional.empty();
+            }
         }
-        return Optional.empty();
     }
 
     public static Optional<MavenScope> of(String name) {
@@ -83,8 +83,7 @@ public enum MavenScope implements Ordered {
             .findFirst();
     }
 
-    @NonNull
-    public static Optional<MavenScope> of(@NonNull Scope scope, Language language) {
+    public static @NonNull Optional<MavenScope> of(@NonNull Scope scope, Language language) {
         switch (scope.getSource()) {
             case MAIN:
                 if (scope.getPhases().contains(Phase.ANNOTATION_PROCESSING) && Language.GROOVY == language) {

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/maven/ParentPom.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/maven/ParentPom.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.projectgen.core.buildtools.maven;
 
+import org.jspecify.annotations.Nullable;
 import io.micronaut.projectgen.core.buildtools.dependencies.Coordinate;
 import io.micronaut.sourcegen.annotations.Builder;
 
@@ -26,9 +27,9 @@ import io.micronaut.sourcegen.annotations.Builder;
  * @param relativePath Relative Path
  */
 @Builder
-public record ParentPom(String groupId, String artifactId, String version, String relativePath) {
+public record ParentPom(@Nullable String groupId, String artifactId, @Nullable String version, @Nullable String relativePath) {
 
-    public ParentPom(Coordinate coordinate, String relativePath) {
+    public ParentPom(Coordinate coordinate, @Nullable String relativePath) {
         this(coordinate.getGroupId(), coordinate.getArtifactId(), coordinate.getVersion(), relativePath);
     }
 

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/maven/ParentPomFeature.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/maven/ParentPomFeature.java
@@ -15,14 +15,12 @@
  */
 package io.micronaut.projectgen.core.buildtools.maven;
 
-import io.micronaut.core.annotation.NonNull;
 import io.micronaut.projectgen.core.feature.Feature;
 
 /**
  * A feature which defines a ParentPom.
  */
 public interface ParentPomFeature extends Feature {
-    @NonNull
     ParentPom getParentPom();
 
 }

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/maven/ParentPomFeature.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/maven/ParentPomFeature.java
@@ -15,12 +15,14 @@
  */
 package io.micronaut.projectgen.core.buildtools.maven;
 
+import org.jspecify.annotations.NonNull;
 import io.micronaut.projectgen.core.feature.Feature;
 
 /**
  * A feature which defines a ParentPom.
  */
 public interface ParentPomFeature extends Feature {
+    @NonNull
     ParentPom getParentPom();
 
 }

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/maven/Profile.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/buildtools/maven/Profile.java
@@ -15,8 +15,8 @@
  */
 package io.micronaut.projectgen.core.buildtools.maven;
 
-import io.micronaut.core.annotation.NonNull;
-import io.micronaut.core.annotation.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import io.micronaut.projectgen.core.buildtools.Property;
 import io.micronaut.projectgen.core.buildtools.dependencies.Dependency;
 import io.micronaut.projectgen.core.rocker.RockerWritable;
@@ -32,8 +32,7 @@ import java.util.Set;
  */
 public class Profile {
 
-    @NonNull
-    private final String id;
+    private final @NonNull String id;
 
     @Nullable
     private final Writable extension;
@@ -58,8 +57,7 @@ public class Profile {
      *
      * @return Profile ID
      */
-    @NonNull
-    public String getId() {
+    public @NonNull String getId() {
         return id;
     }
 
@@ -159,9 +157,13 @@ public class Profile {
      * Builder.
      */
     public static class Builder {
+        @Nullable
         private String id;
+        @Nullable
         private Set<Dependency> dependencies;
+        @Nullable
         private Set<Property> activationProperties;
+        @Nullable
         private Writable extension;
 
         /**
@@ -169,20 +171,17 @@ public class Profile {
          * @param extension Extension
          * @return Builder
          */
-        @NonNull
-        public Builder extension(@NonNull Writable extension) {
+        public @NonNull Builder extension(@NonNull Writable extension) {
             this.extension = extension;
             return this;
         }
-
 
         /**
          *
          * @param dependency Dependency
          * @return Builder
          */
-        @NonNull
-        public Builder dependency(@NonNull Dependency dependency) {
+        public @NonNull Builder dependency(@NonNull Dependency dependency) {
             if (dependencies == null) {
                 dependencies = new HashSet<>();
             }
@@ -195,8 +194,7 @@ public class Profile {
          * @param property property
          * @return Builder
          */
-        @NonNull
-        public Builder activationProperty(@NonNull Property property) {
+        public @NonNull Builder activationProperty(@NonNull Property property) {
             if (activationProperties == null) {
                 activationProperties = new HashSet<>();
             }
@@ -209,8 +207,7 @@ public class Profile {
          * @param id id
          * @return Builder
          */
-        @NonNull
-        public Builder id(@NonNull String id) {
+        public @NonNull Builder id(@NonNull String id) {
             this.id = id;
             return this;
         }
@@ -220,10 +217,11 @@ public class Profile {
          * @return Instantiate a profile
          */
         public Profile build() {
+            String profileId = Objects.requireNonNull(id);
             if (extension == null) {
-                extension = new RockerWritable(profile.template(new Profile(id, activationProperties, dependencies, null)));
+                extension = new RockerWritable(profile.template(new Profile(profileId, activationProperties, dependencies, null)));
             }
-            return new Profile(Objects.requireNonNull(id), activationProperties, dependencies, extension);
+            return new Profile(profileId, activationProperties, dependencies, extension);
         }
     }
 }

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/diff/FeatureDiffer.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/diff/FeatureDiffer.java
@@ -15,7 +15,7 @@
  */
 package io.micronaut.projectgen.core.diff;
 
-import io.micronaut.core.annotation.NonNull;
+import org.jspecify.annotations.NonNull;
 import io.micronaut.projectgen.core.options.Options;
 
 /**
@@ -28,6 +28,5 @@ public interface FeatureDiffer {
      * @return diff
      * @throws Exception Exception generating diff.
      */
-    @NonNull
     String diff(@NonNull Options options) throws Exception;
 }

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/diff/FeatureDiffer.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/diff/FeatureDiffer.java
@@ -28,5 +28,6 @@ public interface FeatureDiffer {
      * @return diff
      * @throws Exception Exception generating diff.
      */
+    @NonNull
     String diff(@NonNull Options options) throws Exception;
 }

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/feature/ApplicationFeature.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/feature/ApplicationFeature.java
@@ -15,7 +15,7 @@
  */
 package io.micronaut.projectgen.core.feature;
 
-import io.micronaut.core.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import io.micronaut.projectgen.core.buildtools.BuildProperties;
 import io.micronaut.projectgen.core.generator.GeneratorContext;
 import io.micronaut.projectgen.core.utils.OptionUtils;

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/feature/AvailableFeatures.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/feature/AvailableFeatures.java
@@ -15,7 +15,7 @@
  */
 package io.micronaut.projectgen.core.feature;
 
-import io.micronaut.core.annotation.NonNull;
+import org.jspecify.annotations.NonNull;
 import io.micronaut.core.order.Ordered;
 import io.micronaut.projectgen.core.options.Options;
 

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/feature/BaseAvailableFeatures.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/feature/BaseAvailableFeatures.java
@@ -15,8 +15,8 @@
  */
 package io.micronaut.projectgen.core.feature;
 
-import io.micronaut.core.annotation.NonNull;
-import io.micronaut.core.annotation.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import io.micronaut.core.order.Ordered;
 import io.micronaut.projectgen.core.options.Options;
 import jakarta.inject.Singleton;

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/feature/Feature.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/feature/Feature.java
@@ -16,8 +16,7 @@
 package io.micronaut.projectgen.core.feature;
 
 import io.micronaut.core.annotation.Indexed;
-import io.micronaut.core.annotation.NonNull;
-import io.micronaut.core.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import io.micronaut.core.naming.Described;
 import io.micronaut.core.naming.Named;
 import io.micronaut.core.order.Ordered;
@@ -39,7 +38,6 @@ public interface Feature extends Named, Ordered, Described {
      *
      * @return the name of the feature
      */
-    @NonNull
     @Override
     String getName();
 
@@ -60,13 +58,14 @@ public interface Feature extends Named, Ordered, Described {
     /**
      * @return The title of the feature
      */
+    @Nullable
     default String getTitle() {
         return null;
     }
 
     @Override
     default String getDescription() {
-        return null;
+        return "";
     }
 
     /**
@@ -77,6 +76,7 @@ public interface Feature extends Named, Ordered, Described {
      *
      * @return The order of the feature
      */
+    @Override
     default int getOrder() {
         return FeaturePhase.DEFAULT.getOrder();
     }

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/feature/Feature.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/feature/Feature.java
@@ -16,6 +16,7 @@
 package io.micronaut.projectgen.core.feature;
 
 import io.micronaut.core.annotation.Indexed;
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import io.micronaut.core.naming.Described;
 import io.micronaut.core.naming.Named;
@@ -38,6 +39,7 @@ public interface Feature extends Named, Ordered, Described {
      *
      * @return the name of the feature
      */
+    @NonNull
     @Override
     String getName();
 

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/feature/FeatureContext.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/feature/FeatureContext.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.projectgen.core.feature;
 
+import org.jspecify.annotations.Nullable;
 import io.micronaut.projectgen.core.buildtools.BuildTool;
 import io.micronaut.projectgen.core.io.ConsoleOutput;
 import io.micronaut.projectgen.core.options.JdkVersion;
@@ -42,6 +43,7 @@ public class FeatureContext {
     private final Options options;
     private final List<Feature> features = new ArrayList<>();
     private final List<FeaturePredicate> exclusions = new ArrayList<>();
+    @Nullable
     private ListIterator<Feature> iterator;
 
     public FeatureContext(Options options,
@@ -93,6 +95,7 @@ public class FeatureContext {
      *
      * @return Language
      */
+    @Nullable
     public Language getLanguage() {
         return options.language();
     }
@@ -101,6 +104,7 @@ public class FeatureContext {
      *
      * @return Test framework
      */
+    @Nullable
     public TestFramework getTestFramework() {
         return options.testFramework();
     }
@@ -109,6 +113,7 @@ public class FeatureContext {
      *
      * @return Build Tool.
      */
+    @Nullable
     public List<BuildTool> getBuildTools() {
         return options.buildTools();
     }
@@ -117,6 +122,7 @@ public class FeatureContext {
      *
      * @return Jdk Version
      */
+    @Nullable
     public JdkVersion getJavaVersion() {
         return options.java();
     }

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/feature/FeatureContext.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/feature/FeatureContext.java
@@ -95,7 +95,6 @@ public class FeatureContext {
      *
      * @return Language
      */
-    @Nullable
     public Language getLanguage() {
         return options.language();
     }
@@ -104,7 +103,6 @@ public class FeatureContext {
      *
      * @return Test framework
      */
-    @Nullable
     public TestFramework getTestFramework() {
         return options.testFramework();
     }
@@ -113,7 +111,6 @@ public class FeatureContext {
      *
      * @return Build Tool.
      */
-    @Nullable
     public List<BuildTool> getBuildTools() {
         return options.buildTools();
     }
@@ -122,7 +119,6 @@ public class FeatureContext {
      *
      * @return Jdk Version
      */
-    @Nullable
     public JdkVersion getJavaVersion() {
         return options.java();
     }

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/feature/FeatureFetcher.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/feature/FeatureFetcher.java
@@ -15,7 +15,7 @@
  */
 package io.micronaut.projectgen.core.feature;
 
-import io.micronaut.core.annotation.NonNull;
+import org.jspecify.annotations.NonNull;
 import io.micronaut.projectgen.core.options.Options;
 
 import java.util.List;
@@ -29,6 +29,5 @@ public interface FeatureFetcher {
      * @param options project options
      * @return features
      */
-    @NonNull
     List<FeatureResponse> fetch(@NonNull Options options);
 }

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/feature/FeatureFetcher.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/feature/FeatureFetcher.java
@@ -29,5 +29,6 @@ public interface FeatureFetcher {
      * @param options project options
      * @return features
      */
+    @NonNull
     List<FeatureResponse> fetch(@NonNull Options options);
 }

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/feature/FeatureResponse.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/feature/FeatureResponse.java
@@ -16,6 +16,7 @@
 package io.micronaut.projectgen.core.feature;
 
 import io.micronaut.serde.annotation.Serdeable;
+import org.jspecify.annotations.Nullable;
 
 /**
  *
@@ -27,8 +28,8 @@ import io.micronaut.serde.annotation.Serdeable;
  */
 @Serdeable
 public record FeatureResponse(String name,
-                             String title,
-                             String description,
+                             @Nullable String title,
+                             @Nullable String description,
                              boolean preview,
                              boolean community) {
 }

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/feature/Features.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/feature/Features.java
@@ -22,7 +22,6 @@ import io.micronaut.projectgen.core.options.JdkVersion;
 import io.micronaut.projectgen.core.options.Options;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -43,7 +42,6 @@ public class Features extends ArrayList<String> {
     private LanguageFeature languageFeature;
     @Nullable
     private TestFeature testFeature;
-    @Nullable
     private final JdkVersion javaVersion;
 
     public Features(GeneratorContext context, Set<Feature> featureList, Options options) {
@@ -62,7 +60,7 @@ public class Features extends ArrayList<String> {
             }
         }
         this.javaVersion = options.java();
-        this.buildTools = options.buildTools() == null ? Collections.emptyList() : options.buildTools();
+        this.buildTools = options.buildTools();
     }
 
     /**
@@ -129,7 +127,6 @@ public class Features extends ArrayList<String> {
      *
      * @return The Java version
      */
-    @Nullable
     public JdkVersion javaVersion() {
         return javaVersion;
     }

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/feature/Features.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/feature/Features.java
@@ -15,12 +15,14 @@
  */
 package io.micronaut.projectgen.core.feature;
 
+import org.jspecify.annotations.Nullable;
 import io.micronaut.projectgen.core.buildtools.BuildTool;
 import io.micronaut.projectgen.core.generator.GeneratorContext;
 import io.micronaut.projectgen.core.options.JdkVersion;
 import io.micronaut.projectgen.core.options.Options;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -35,9 +37,13 @@ public class Features extends ArrayList<String> {
     private final Set<Feature> featureList;
     private final List<BuildTool> buildTools;
     private final GeneratorContext context;
+    @Nullable
     private ApplicationFeature applicationFeature;
+    @Nullable
     private LanguageFeature languageFeature;
+    @Nullable
     private TestFeature testFeature;
+    @Nullable
     private final JdkVersion javaVersion;
 
     public Features(GeneratorContext context, Set<Feature> featureList, Options options) {
@@ -56,7 +62,7 @@ public class Features extends ArrayList<String> {
             }
         }
         this.javaVersion = options.java();
-        this.buildTools = options.buildTools();
+        this.buildTools = options.buildTools() == null ? Collections.emptyList() : options.buildTools();
     }
 
     /**
@@ -88,6 +94,7 @@ public class Features extends ArrayList<String> {
      *
      * @return The Application Feature
      */
+    @Nullable
     public ApplicationFeature application() {
         return applicationFeature;
     }
@@ -96,6 +103,7 @@ public class Features extends ArrayList<String> {
      *
      * @return The Language
      */
+    @Nullable
     public LanguageFeature language() {
         return languageFeature;
     }
@@ -104,6 +112,7 @@ public class Features extends ArrayList<String> {
      *
      * @return The Test Feature
      */
+    @Nullable
     public TestFeature testFramework() {
         return testFeature;
     }
@@ -120,6 +129,7 @@ public class Features extends ArrayList<String> {
      *
      * @return The Java version
      */
+    @Nullable
     public JdkVersion javaVersion() {
         return javaVersion;
     }

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/feature/FeaturesMapper.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/feature/FeaturesMapper.java
@@ -15,7 +15,7 @@
  */
 package io.micronaut.projectgen.core.feature;
 
-import io.micronaut.core.annotation.NonNull;
+import org.jspecify.annotations.NonNull;
 import jakarta.inject.Singleton;
 
 /**
@@ -28,11 +28,11 @@ public class FeaturesMapper {
      * @param feature Feature
      * @return A FeatureResponse
      */
-    @NonNull
-    public FeatureResponse toFeatureResponse(@NonNull Feature feature) {
+    public @NonNull FeatureResponse toFeatureResponse(@NonNull Feature feature) {
+        String description = feature.getDescription();
         return new FeatureResponse(feature.getName(),
             feature.getTitle(),
-            feature.getDescription(),
+            description.isEmpty() ? null : description,
             feature.isPreview(),
             feature.isCommunity());
     }

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/feature/config/ApplicationConfiguration.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/feature/config/ApplicationConfiguration.java
@@ -16,7 +16,7 @@
 package io.micronaut.projectgen.core.feature.config;
 
 import io.micronaut.context.env.Environment;
-import io.micronaut.core.annotation.NonNull;
+import org.jspecify.annotations.NonNull;
 
 /**
  * Application configuration.

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/feature/config/BootstrapConfiguration.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/feature/config/BootstrapConfiguration.java
@@ -16,7 +16,7 @@
 package io.micronaut.projectgen.core.feature.config;
 
 import io.micronaut.context.env.Environment;
-import io.micronaut.core.annotation.NonNull;
+import org.jspecify.annotations.NonNull;
 import io.micronaut.projectgen.core.buildtools.Source;
 
 /**

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/feature/config/Config4k.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/feature/config/Config4k.java
@@ -16,7 +16,7 @@
 package io.micronaut.projectgen.core.feature.config;
 
 import io.micronaut.context.annotation.Requires;
-import io.micronaut.core.annotation.NonNull;
+import org.jspecify.annotations.NonNull;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.projectgen.core.feature.ConfigurationFeature;
 import io.micronaut.projectgen.core.feature.Feature;
@@ -42,15 +42,13 @@ public class Config4k implements ConfigurationFeature, KotlinSpecificFeature {
 
     private static final String EXTENSION = "conf";
 
-    @NonNull
     @Override
-    public String getName() {
+    public @NonNull String getName() {
         return "config4k";
     }
 
-    @NonNull
     @Override
-    public String getTitle() {
+    public @NonNull String getTitle() {
         return "Config4k - Config for Kotlin";
     }
 
@@ -76,9 +74,8 @@ public class Config4k implements ConfigurationFeature, KotlinSpecificFeature {
         }
     }
 
-    @NonNull
     @Override
-    public String getDescription() {
+    public @NonNull String getDescription() {
         return "Define configuration with config4k, a typesafe configuration format for Kotlin based on HOCON";
     }
 

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/feature/config/Configuration.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/feature/config/Configuration.java
@@ -15,7 +15,8 @@
  */
 package io.micronaut.projectgen.core.feature.config;
 
-import io.micronaut.core.annotation.NonNull;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.core.util.StringUtils;
 
@@ -60,6 +61,7 @@ public class Configuration extends LinkedHashMap<String, Object> {
      * configuration path for source set.
      *
      * @param sourceSet where the configuration is rooted, e.g. main, test
+     * @return configuration path
      */
     public static String sourceSetPath(@NonNull String sourceSet) {
         return "src/" + sourceSet + "/resources/";
@@ -73,6 +75,7 @@ public class Configuration extends LinkedHashMap<String, Object> {
         return false;
     }
 
+    @Nullable
     @Override
     public Object get(Object key) {
         if (key != null && containsKey(key)) {
@@ -136,8 +139,7 @@ public class Configuration extends LinkedHashMap<String, Object> {
      *
      * @return path
      */
-    @NonNull
-    public String getPath() {
+    public @NonNull String getPath() {
         return path;
     }
 
@@ -145,8 +147,7 @@ public class Configuration extends LinkedHashMap<String, Object> {
      *
      * @return filename
      */
-    @NonNull
-    public String getFileName() {
+    public @NonNull String getFileName() {
         return fileName;
     }
 
@@ -155,8 +156,7 @@ public class Configuration extends LinkedHashMap<String, Object> {
      * @param extension extension
      * @return full path
      */
-    @NonNull
-    public String getFullPath(String extension) {
+    public @NonNull String getFullPath(String extension) {
         return path + fileName + "." + extension;
     }
 
@@ -164,8 +164,7 @@ public class Configuration extends LinkedHashMap<String, Object> {
      *
      * @return template key
      */
-    @NonNull
-    public String getTemplateKey() {
+    public @NonNull String getTemplateKey() {
         return templateKey;
     }
 
@@ -210,6 +209,7 @@ public class Configuration extends LinkedHashMap<String, Object> {
         return true;
     }
 
+    @Nullable
     private Object getNested(String key) {
         if (key.indexOf('.') == -1) {
             return null;

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/feature/config/NestedConfiguration.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/feature/config/NestedConfiguration.java
@@ -15,7 +15,7 @@
  */
 package io.micronaut.projectgen.core.feature.config;
 
-import io.micronaut.core.annotation.NonNull;
+import org.jspecify.annotations.NonNull;
 
 import java.util.Map;
 
@@ -24,11 +24,9 @@ import java.util.Map;
  */
 public class NestedConfiguration {
 
-    @NonNull
-    private final String path;
+    private final @NonNull String path;
 
-    @NonNull
-    private final Map<String, Object> configuration;
+    private final @NonNull Map<String, Object> configuration;
 
     /**
      * Constructor.
@@ -52,8 +50,7 @@ public class NestedConfiguration {
      *
      * @return path
      */
-    @NonNull
-    public String getPath() {
+    public @NonNull String getPath() {
         return path;
     }
 
@@ -61,8 +58,7 @@ public class NestedConfiguration {
      *
      * @return configuration.
      */
-    @NonNull
-    public Map<String, Object> getConfiguration() {
+    public @NonNull Map<String, Object> getConfiguration() {
         return configuration;
     }
 }

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/feature/config/Yaml.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/feature/config/Yaml.java
@@ -16,7 +16,7 @@
 package io.micronaut.projectgen.core.feature.config;
 
 import io.micronaut.context.annotation.Requires;
-import io.micronaut.core.annotation.NonNull;
+import org.jspecify.annotations.NonNull;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.projectgen.core.feature.ConfigurationFeature;
 import io.micronaut.projectgen.core.generator.GeneratorContext;
@@ -49,8 +49,7 @@ public class Yaml implements ConfigurationFeature {
             .build();
 
     @Override
-    @NonNull
-    public String getName() {
+    public @NonNull String getName() {
         return NAME;
     }
 

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/generator/ContextFactory.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/generator/ContextFactory.java
@@ -15,7 +15,6 @@
  */
 package io.micronaut.projectgen.core.generator;
 
-import io.micronaut.core.annotation.Nullable;
 import io.micronaut.projectgen.core.buildtools.dependencies.CoordinateResolver;
 import io.micronaut.projectgen.core.feature.AvailableFeatures;
 import io.micronaut.projectgen.core.feature.DefaultFeature;
@@ -27,6 +26,7 @@ import io.micronaut.projectgen.core.openrewrite.RecipeFetcher;
 import io.micronaut.projectgen.core.options.Options;
 import io.micronaut.projectgen.core.utils.NameUtils;
 import jakarta.inject.Singleton;
+import org.jspecify.annotations.Nullable;
 import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.List;
@@ -41,7 +41,6 @@ public class ContextFactory {
     private final FeatureValidator featureValidator;
     private final ProjectNameValidator projectNameValidator;
     private final CoordinateResolver coordinateResolver;
-    @Nullable
     private final RecipeFetcher recipeFetcher;
 
     public ContextFactory(FeatureValidator featureValidator,
@@ -51,7 +50,7 @@ public class ContextFactory {
         this.featureValidator = featureValidator;
         this.coordinateResolver = coordinateResolver;
         this.projectNameValidator = projectNameValidator;
-        this.recipeFetcher = recipeFetcher;
+        this.recipeFetcher = recipeFetcher == null ? RecipeFetcher.NOOP : recipeFetcher;
     }
 
     /**

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/generator/DefaultProjectGenerator.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/generator/DefaultProjectGenerator.java
@@ -15,7 +15,7 @@
  */
 package io.micronaut.projectgen.core.generator;
 
-import io.micronaut.core.annotation.NonNull;
+import org.jspecify.annotations.NonNull;
 import io.micronaut.projectgen.core.feature.AvailableFeatures;
 import io.micronaut.projectgen.core.io.ConsoleOutput;
 import io.micronaut.projectgen.core.io.FileSystemOutputHandler;

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/generator/GeneratorContext.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/generator/GeneratorContext.java
@@ -15,7 +15,7 @@
  */
 package io.micronaut.projectgen.core.generator;
 
-import io.micronaut.core.annotation.NonNull;
+import org.jspecify.annotations.NonNull;
 import io.micronaut.projectgen.core.buildtools.BuildTool;
 import io.micronaut.projectgen.core.buildtools.dependencies.Coordinate;
 import io.micronaut.projectgen.core.buildtools.dependencies.CoordinateResolver;
@@ -87,15 +87,14 @@ public class GeneratorContext {
      * @return The language
      */
     @NonNull public Language getLanguage() {
-        return options.language();
+        return options.language() == null ? Language.JAVA : options.language();
     }
 
     /**
      *
      * @return Options
      */
-    @NonNull
-    public Options getOptions() {
+    public @NonNull Options getOptions() {
         return options;
     }
 
@@ -103,17 +102,15 @@ public class GeneratorContext {
      * @return The test framework
      */
     @Deprecated(forRemoval = true)
-    @NonNull
-    public BuildTool getBuildTool() {
-        return options.getBuildTool();
+    public @NonNull BuildTool getBuildTool() {
+        return options.getBuildTool() == null ? BuildTool.GRADLE : options.getBuildTool();
     }
 
     /**
      * @return The test framework
      */
-    @NonNull
-    public TestFramework getTestFramework() {
-        return options.testFramework();
+    public @NonNull TestFramework getTestFramework() {
+        return options.testFramework() == null ? TestFramework.DEFAULT_OPTION : options.testFramework();
     }
 
     /**
@@ -134,7 +131,7 @@ public class GeneratorContext {
      * @return The JDK version
      */
     @NonNull public JdkVersion getJdkVersion() {
-        return options.java();
+        return options.java() == null ? JdkVersion.JDK_25 : options.java();
     }
 
     /**

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/generator/GeneratorContext.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/generator/GeneratorContext.java
@@ -87,7 +87,7 @@ public class GeneratorContext {
      * @return The language
      */
     @NonNull public Language getLanguage() {
-        return options.language() == null ? Language.JAVA : options.language();
+        return options.language();
     }
 
     /**
@@ -110,7 +110,7 @@ public class GeneratorContext {
      * @return The test framework
      */
     public @NonNull TestFramework getTestFramework() {
-        return options.testFramework() == null ? TestFramework.DEFAULT_OPTION : options.testFramework();
+        return options.testFramework();
     }
 
     /**
@@ -131,7 +131,7 @@ public class GeneratorContext {
      * @return The JDK version
      */
     @NonNull public JdkVersion getJdkVersion() {
-        return options.java() == null ? JdkVersion.JDK_25 : options.java();
+        return options.java();
     }
 
     /**

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/generator/ModuleAttributes.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/generator/ModuleAttributes.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.projectgen.core.generator;
 
+import org.jspecify.annotations.Nullable;
 import io.micronaut.projectgen.core.buildtools.dependencies.Coordinate;
 import io.micronaut.projectgen.core.buildtools.maven.Packaging;
 import io.micronaut.projectgen.core.buildtools.maven.ParentPom;
@@ -23,16 +24,22 @@ import io.micronaut.projectgen.core.buildtools.maven.ParentPom;
  * Module Attributes.
  */
 public class ModuleAttributes {
+    @Nullable
     private ParentPom parentPom;
+    @Nullable
     private String packaging;
+    @Nullable
     private Coordinate coordinate;
+    @Nullable
     private String name;
+    @Nullable
     private String description;
 
     /**
      *
      * @return Parent POM
      */
+    @Nullable
     public ParentPom getParentPom() {
         return parentPom;
     }
@@ -41,7 +48,7 @@ public class ModuleAttributes {
      *
      * @param parentPom Parent POM
      */
-    public void setParentPom(ParentPom parentPom) {
+    public void setParentPom(@Nullable ParentPom parentPom) {
         this.parentPom = parentPom;
     }
 
@@ -49,6 +56,7 @@ public class ModuleAttributes {
      *
      * @return Coordinate
      */
+    @Nullable
     public Coordinate getCoordinate() {
         return coordinate;
     }
@@ -57,7 +65,7 @@ public class ModuleAttributes {
      *
      * @param coordinate Coordinate
      */
-    public void setCoordinate(Coordinate coordinate) {
+    public void setCoordinate(@Nullable Coordinate coordinate) {
         this.coordinate = coordinate;
     }
 
@@ -65,6 +73,7 @@ public class ModuleAttributes {
      *
      * @return name
      */
+    @Nullable
     public String getName() {
         return name;
     }
@@ -73,7 +82,7 @@ public class ModuleAttributes {
      *
      * @param name name
      */
-    public void setName(String name) {
+    public void setName(@Nullable String name) {
         this.name = name;
     }
 
@@ -81,6 +90,7 @@ public class ModuleAttributes {
      *
      * @return Description
      */
+    @Nullable
     public String getDescription() {
         return description;
     }
@@ -89,7 +99,7 @@ public class ModuleAttributes {
      *
      * @param description Description
      */
-    public void setDescription(String description) {
+    public void setDescription(@Nullable String description) {
         this.description = description;
     }
 
@@ -97,6 +107,7 @@ public class ModuleAttributes {
      *
      * @return Packaging
      */
+    @Nullable
     public String getPackaging() {
         return packaging;
     }
@@ -113,7 +124,7 @@ public class ModuleAttributes {
      *
      * @param packaging packaging
      */
-    public void setPackaging(String packaging) {
+    public void setPackaging(@Nullable String packaging) {
         this.packaging = packaging;
     }
 }

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/generator/ModuleContext.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/generator/ModuleContext.java
@@ -17,7 +17,8 @@ package io.micronaut.projectgen.core.generator;
 
 import com.fizzed.rocker.RockerModel;
 import io.micronaut.context.env.Environment;
-import io.micronaut.core.annotation.NonNull;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.projectgen.core.buildtools.BuildPlugin;
 import io.micronaut.projectgen.core.buildtools.BuildProperties;
@@ -119,10 +120,10 @@ public record ModuleContext(CoordinateResolver coordinateResolver,
     }
 
     public ModuleContext(CoordinateResolver coordinateResolver, RecipeFetcher recipeFetcher) {
-        this(null, coordinateResolver, recipeFetcher);
+        this((String) null, coordinateResolver, recipeFetcher);
     }
 
-    public ModuleContext(String name, CoordinateResolver coordinateResolver, RecipeFetcher recipeFetcher) {
+    public ModuleContext(@Nullable String name, CoordinateResolver coordinateResolver, RecipeFetcher recipeFetcher) {
         this(coordinateResolver,
             recipeFetcher,
             new ModuleAttributes(),
@@ -162,8 +163,7 @@ public record ModuleContext(CoordinateResolver coordinateResolver,
      *
      * @return Build plugins
      */
-    @NonNull
-    public Set<BuildPlugin> getBuildPlugins() {
+    public @NonNull Set<BuildPlugin> getBuildPlugins() {
         return buildPlugins;
     }
 
@@ -178,8 +178,7 @@ public record ModuleContext(CoordinateResolver coordinateResolver,
     /**
      * @return All Configurations
      */
-    @NonNull
-    public Set<Configuration> getConfigurations() {
+    public @NonNull Set<Configuration> getConfigurations() {
         Set<Configuration> allConfigurations = new HashSet<>();
         allConfigurations.add(configuration);
         allConfigurations.addAll(configurationByEnvironment.values());
@@ -199,7 +198,7 @@ public record ModuleContext(CoordinateResolver coordinateResolver,
                                         @NonNull String artifactId,
                                         @NonNull Scope scope) {
         return getDependencies().stream()
-            .anyMatch(dependency -> dependency.getGroupId().equals(groupId) &&
+            .anyMatch(dependency -> java.util.Objects.equals(dependency.getGroupId(), groupId) &&
                 dependency.getArtifactId().equals(artifactId)
                 && dependency.getScope() == scope);
     }
@@ -218,9 +217,9 @@ public record ModuleContext(CoordinateResolver coordinateResolver,
         if (OptionUtils.hasGradleBuildTool(options)) {
             for (Dependency d : recipeFetcher.findAllByRecipeNameAndBuildTool(recipeName, BuildTool.GRADLE)) {
                 if (dependencies.stream().noneMatch(dep ->
-                    dep.getGroupId().equals(d.getGroupId()) &&
+                    java.util.Objects.equals(dep.getGroupId(), d.getGroupId()) &&
                         dep.getArtifactId().equals(d.getArtifactId()) &&
-                        dep.getScope().equals(d.getScope())
+                        java.util.Objects.equals(dep.getScope(), d.getScope())
                 )) {
                     dependencies.add(d);
                 }
@@ -325,7 +324,9 @@ public record ModuleContext(CoordinateResolver coordinateResolver,
      * @param testRockerModelProvider testRockerModelProvider
      */
     public void addTemplate(Options options, String name, String path, TestRockerModelProvider testRockerModelProvider) {
-        RockerModel rockerModel = testRockerModelProvider.findModel(options.language(), options.testFramework());
+        RockerModel rockerModel = options.language() == null || options.testFramework() == null
+            ? null
+            : testRockerModelProvider.findModel(options.language(), options.testFramework());
         if (rockerModel != null) {
             addTemplate(name, new RockerTemplate(path, rockerModel));
         }
@@ -403,17 +404,14 @@ public record ModuleContext(CoordinateResolver coordinateResolver,
         dependencyContext.addDependency(dependency);
     }
 
-    @NonNull
-    public Collection<Dependency> getDependencies() {
+    public @NonNull Collection<Dependency> getDependencies() {
         return dependencyContext.getDependencies();
     }
 
-    @NonNull
-    public Collection<Dependency> getDependenciesByBuildTool(@NonNull BuildTool buildTool) {
+    public @NonNull Collection<Dependency> getDependenciesByBuildTool(@NonNull BuildTool buildTool) {
         return dependencyContext.getDependenciesByBuildTool(buildTool);
     }
 
-    @NonNull
     public void addDependency(Dependency.Builder dependencyBuilder) {
         dependencyContext.addDependency(dependencyBuilder);
     }
@@ -463,7 +461,7 @@ public record ModuleContext(CoordinateResolver coordinateResolver,
     public boolean hasDependency(@NonNull String groupId,
                                  @NonNull String artifactId) {
         return getDependencies().stream()
-            .anyMatch(dependency -> dependency.getGroupId().equals(groupId) &&
+            .anyMatch(dependency -> java.util.Objects.equals(dependency.getGroupId(), groupId) &&
                 dependency.getArtifactId().equals(artifactId));
     }
 
@@ -474,7 +472,7 @@ public record ModuleContext(CoordinateResolver coordinateResolver,
      */
     public long countDependencies(@NonNull String groupId) {
         return getDependencies().stream()
-            .filter(dependency -> dependency.getGroupId().equals(groupId))
+            .filter(dependency -> java.util.Objects.equals(dependency.getGroupId(), groupId))
             .count();
     }
 

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/generator/ModuleContext.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/generator/ModuleContext.java
@@ -324,9 +324,7 @@ public record ModuleContext(CoordinateResolver coordinateResolver,
      * @param testRockerModelProvider testRockerModelProvider
      */
     public void addTemplate(Options options, String name, String path, TestRockerModelProvider testRockerModelProvider) {
-        RockerModel rockerModel = options.language() == null || options.testFramework() == null
-            ? null
-            : testRockerModelProvider.findModel(options.language(), options.testFramework());
+        RockerModel rockerModel = testRockerModelProvider.findModel(options.language(), options.testFramework());
         if (rockerModel != null) {
             addTemplate(name, new RockerTemplate(path, rockerModel));
         }

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/generator/ProjectGenerator.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/generator/ProjectGenerator.java
@@ -16,7 +16,7 @@
 package io.micronaut.projectgen.core.generator;
 
 import io.micronaut.context.annotation.DefaultImplementation;
-import io.micronaut.core.annotation.NonNull;
+import org.jspecify.annotations.NonNull;
 import io.micronaut.projectgen.core.io.ConsoleOutput;
 import io.micronaut.projectgen.core.io.OutputHandler;
 import io.micronaut.projectgen.core.options.Options;
@@ -39,7 +39,5 @@ public interface ProjectGenerator {
         generate(options, outputHandler, ConsoleOutput.NOOP);
     }
 
-    default void generate(@NonNull Options options, @NonNull OutputHandler outputHandler, ConsoleOutput consoleOutput) throws Exception {
-        generate(options, outputHandler, consoleOutput);
-    }
+    void generate(@NonNull Options options, @NonNull OutputHandler outputHandler, ConsoleOutput consoleOutput) throws Exception;
 }

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/generator/ProjectIdentifier.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/generator/ProjectIdentifier.java
@@ -15,6 +15,8 @@
  */
 package io.micronaut.projectgen.core.generator;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Project Identifier.
  */
@@ -22,7 +24,7 @@ public class ProjectIdentifier {
     private final String packageName;
     private final String name;
 
-    public ProjectIdentifier(String packageName, String name) {
+    public ProjectIdentifier(@Nullable String packageName, String name) {
         packageName = packageName != null ? packageName.replaceAll("\\.*$", "") : "";
         this.packageName = packageName;
         this.name = name;

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/io/DefaultPreviewGenerator.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/io/DefaultPreviewGenerator.java
@@ -15,7 +15,7 @@
  */
 package io.micronaut.projectgen.core.io;
 
-import io.micronaut.core.annotation.NonNull;
+import org.jspecify.annotations.NonNull;
 import io.micronaut.projectgen.core.generator.ProjectGenerator;
 import io.micronaut.projectgen.core.options.Options;
 import jakarta.inject.Singleton;
@@ -31,8 +31,7 @@ class DefaultPreviewGenerator implements PreviewGenerator {
     }
 
     @Override
-    @NonNull
-    public Map<String, String> generate(@NonNull Options options) throws Exception {
+    public @NonNull Map<String, String> generate(@NonNull Options options) throws Exception {
         MapOutputHandler outputHandler = new MapOutputHandler();
         projectGenerator.generate(options, outputHandler);
         return outputHandler.getProject();

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/io/MapOutputHandler.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/io/MapOutputHandler.java
@@ -16,6 +16,8 @@
 package io.micronaut.projectgen.core.io;
 
 import io.micronaut.projectgen.core.template.Template;
+import org.jspecify.annotations.Nullable;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -50,7 +52,7 @@ public class MapOutputHandler implements OutputHandler {
     }
 
     @Override
-    public String getOutputLocation() {
+    public @Nullable String getOutputLocation() {
         return null;
     }
 

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/io/OutputHandler.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/io/OutputHandler.java
@@ -16,6 +16,8 @@
 package io.micronaut.projectgen.core.io;
 
 import io.micronaut.projectgen.core.template.Template;
+import org.jspecify.annotations.Nullable;
+
 import java.io.Closeable;
 import java.io.IOException;
 
@@ -28,6 +30,7 @@ public interface OutputHandler extends Closeable {
 
     void write(String path, Template contents) throws IOException;
 
+    @Nullable
     String getOutputLocation();
 
 }

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/io/PreviewGenerator.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/io/PreviewGenerator.java
@@ -16,7 +16,7 @@
 package io.micronaut.projectgen.core.io;
 
 import io.micronaut.context.annotation.DefaultImplementation;
-import io.micronaut.core.annotation.NonNull;
+import org.jspecify.annotations.NonNull;
 import io.micronaut.projectgen.core.options.Options;
 import java.util.Map;
 
@@ -32,6 +32,5 @@ public interface PreviewGenerator {
      * @return Project Preview
      * @throws Exception Exception generating preview
      */
-    @NonNull
     Map<String, String> generate(@NonNull Options options) throws Exception;
 }

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/io/PreviewGenerator.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/io/PreviewGenerator.java
@@ -32,5 +32,6 @@ public interface PreviewGenerator {
      * @return Project Preview
      * @throws Exception Exception generating preview
      */
+    @NonNull
     Map<String, String> generate(@NonNull Options options) throws Exception;
 }

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/io/TreeNodeGenerator.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/io/TreeNodeGenerator.java
@@ -32,6 +32,7 @@ public interface TreeNodeGenerator {
      * @param project Project
      * @return Tree Node
      */
+    @NonNull
     TreeNode generate(@NonNull Map<String, String> project);
 
     /**
@@ -39,5 +40,6 @@ public interface TreeNodeGenerator {
      * @param options Project Options
      * @return Tree Node
      */
+    @NonNull
     TreeNode generate(@NonNull Options options) throws Exception;
 }

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/io/TreeNodeGenerator.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/io/TreeNodeGenerator.java
@@ -16,7 +16,7 @@
 package io.micronaut.projectgen.core.io;
 
 import io.micronaut.context.annotation.DefaultImplementation;
-import io.micronaut.core.annotation.NonNull;
+import org.jspecify.annotations.NonNull;
 import io.micronaut.projectgen.core.options.Options;
 
 import java.util.Map;
@@ -32,7 +32,6 @@ public interface TreeNodeGenerator {
      * @param project Project
      * @return Tree Node
      */
-    @NonNull
     TreeNode generate(@NonNull Map<String, String> project);
 
     /**
@@ -40,6 +39,5 @@ public interface TreeNodeGenerator {
      * @param options Project Options
      * @return Tree Node
      */
-    @NonNull
     TreeNode generate(@NonNull Options options) throws Exception;
 }

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/io/zip/DefaultZipGenerator.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/io/zip/DefaultZipGenerator.java
@@ -16,8 +16,8 @@
 package io.micronaut.projectgen.core.io.zip;
 
 import io.micronaut.core.annotation.Internal;
-import io.micronaut.core.annotation.NonNull;
-import io.micronaut.core.annotation.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import io.micronaut.core.io.Writable;
 import io.micronaut.projectgen.core.generator.ProjectGenerator;
 import io.micronaut.projectgen.core.options.Options;
@@ -41,8 +41,7 @@ class DefaultZipGenerator implements ZipGenerator {
     }
 
     @Override
-    @NonNull
-    public Writable zip(@NonNull Options options) {
+    public @NonNull Writable zip(@NonNull Options options) {
         return new Writable() {
             @Override
             public void writeTo(OutputStream outputStream,

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/io/zip/ZipGenerator.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/io/zip/ZipGenerator.java
@@ -29,5 +29,6 @@ public interface ZipGenerator {
      * @param options Project Options
      * @return ZIP wrapped in a {@link Writable}.
      */
+    @NonNull
     Writable zip(@NonNull Options options);
 }

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/io/zip/ZipGenerator.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/io/zip/ZipGenerator.java
@@ -15,7 +15,7 @@
  */
 package io.micronaut.projectgen.core.io.zip;
 
-import io.micronaut.core.annotation.NonNull;
+import org.jspecify.annotations.NonNull;
 import io.micronaut.core.io.Writable;
 import io.micronaut.projectgen.core.options.Options;
 
@@ -29,6 +29,5 @@ public interface ZipGenerator {
      * @param options Project Options
      * @return ZIP wrapped in a {@link Writable}.
      */
-    @NonNull
     Writable zip(@NonNull Options options);
 }

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/io/zip/ZipOutputHandler.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/io/zip/ZipOutputHandler.java
@@ -19,6 +19,7 @@ import io.micronaut.core.util.StringUtils;
 import io.micronaut.projectgen.core.generator.Project;
 import io.micronaut.projectgen.core.io.OutputHandler;
 import io.micronaut.projectgen.core.template.Template;
+import org.jspecify.annotations.Nullable;
 import org.apache.commons.compress.archivers.zip.UnixStat;
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
@@ -36,7 +37,9 @@ import java.nio.file.Paths;
 public class ZipOutputHandler implements OutputHandler {
 
     private final ZipArchiveOutputStream zipOutputStream;
+    @Nullable
     private final File zip;
+    @Nullable
     private final String directory;
 
     public ZipOutputHandler(Project project) throws IOException {
@@ -64,7 +67,7 @@ public class ZipOutputHandler implements OutputHandler {
     }
 
     @Override
-    public String getOutputLocation() {
+    public @Nullable String getOutputLocation() {
         if (zip == null) {
             return null;
         } else {

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/openrewrite/OpenRewriteFeature.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/openrewrite/OpenRewriteFeature.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.projectgen.core.openrewrite;
 
+import org.jspecify.annotations.Nullable;
 import io.micronaut.projectgen.core.feature.Feature;
 import io.micronaut.projectgen.core.generator.GeneratorContext;
 import io.micronaut.projectgen.core.generator.ModuleContext;
@@ -46,8 +47,9 @@ public interface OpenRewriteFeature extends Feature {
         }
     }
 
+    @Nullable
     @Override
-    default String getFrameworkDocumentation(GeneratorContext gc) {
+    default String getFrameworkDocumentation(@Nullable GeneratorContext gc) {
         if (gc == null) {
             return null;
         }
@@ -58,8 +60,9 @@ public interface OpenRewriteFeature extends Feature {
             .orElse(null);
     }
 
+    @Nullable
     @Override
-    default String getThirdPartyDocumentation(GeneratorContext gc) {
+    default String getThirdPartyDocumentation(@Nullable GeneratorContext gc) {
         if (gc == null) {
             return null;
         }

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/openrewrite/RecipeFetcher.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/openrewrite/RecipeFetcher.java
@@ -15,7 +15,7 @@
  */
 package io.micronaut.projectgen.core.openrewrite;
 
-import io.micronaut.core.annotation.NonNull;
+import org.jspecify.annotations.NonNull;
 import io.micronaut.projectgen.core.buildtools.BuildPlugin;
 import io.micronaut.projectgen.core.buildtools.BuildTool;
 import io.micronaut.projectgen.core.buildtools.dependencies.Dependency;
@@ -28,29 +28,69 @@ import java.util.Properties;
  * Utility class to interact with OpenRewrite recipes.
  */
 public interface RecipeFetcher {
+    RecipeFetcher NOOP = new RecipeFetcher() {
+        @Override
+        public Optional<String> findFrameworkDocumentationByRecipeName(String recipeName) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<String> findThirdPartyDocumentationByRecipeName(String recipeName) {
+            return Optional.empty();
+        }
+
+        @Override
+        public List<Dependency> findAllByRecipeNameAndBuildTool(@NonNull String recipe, @NonNull BuildTool buildTool) {
+            return List.of();
+        }
+
+        @Override
+        public Optional<Properties> findPropertiesByRecipeName(@NonNull String recipe) {
+            return Optional.empty();
+        }
+
+        @Override
+        public List<FileContents> findAllFilesByRecipeName(@NonNull String recipe) {
+            return List.of();
+        }
+
+        @Override
+        public Optional<Properties> findBootstrapPropertiesByRecipeName(@NonNull String recipeName) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<Properties> findDevPropertiesByRecipeName(@NonNull String recipeName) {
+            return Optional.empty();
+        }
+
+        @Override
+        public List<BuildPlugin> findAllBuildPluginsByRecipeNameAndBuildTool(@NonNull String recipeName, @NonNull BuildTool buildTool) {
+            return List.of();
+        }
+
+        @Override
+        public Optional<Properties> findMavenBuildPropertiesByRecipeName(@NonNull String recipeName) {
+            return Optional.empty();
+        }
+    };
+
     Optional<String> findFrameworkDocumentationByRecipeName(String recipeName);
 
     Optional<String> findThirdPartyDocumentationByRecipeName(String recipeName);
 
-    @NonNull
     List<Dependency> findAllByRecipeNameAndBuildTool(@NonNull String recipe, @NonNull BuildTool buildTool);
 
-    @NonNull
     Optional<Properties> findPropertiesByRecipeName(@NonNull String recipe);
 
-    @NonNull
     List<FileContents> findAllFilesByRecipeName(@NonNull String recipe);
 
-    @NonNull
     Optional<Properties> findBootstrapPropertiesByRecipeName(@NonNull String recipeName);
 
-    @NonNull
     Optional<Properties> findDevPropertiesByRecipeName(@NonNull String recipeName);
 
-    @NonNull
     List<BuildPlugin> findAllBuildPluginsByRecipeNameAndBuildTool(@NonNull String recipeName, @NonNull BuildTool buildTool);
 
-    @NonNull
     Optional<Properties> findMavenBuildPropertiesByRecipeName(@NonNull String recipeName);
 
 }

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/openrewrite/RecipeFetcher.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/openrewrite/RecipeFetcher.java
@@ -79,18 +79,25 @@ public interface RecipeFetcher {
 
     Optional<String> findThirdPartyDocumentationByRecipeName(String recipeName);
 
+    @NonNull
     List<Dependency> findAllByRecipeNameAndBuildTool(@NonNull String recipe, @NonNull BuildTool buildTool);
 
+    @NonNull
     Optional<Properties> findPropertiesByRecipeName(@NonNull String recipe);
 
+    @NonNull
     List<FileContents> findAllFilesByRecipeName(@NonNull String recipe);
 
+    @NonNull
     Optional<Properties> findBootstrapPropertiesByRecipeName(@NonNull String recipeName);
 
+    @NonNull
     Optional<Properties> findDevPropertiesByRecipeName(@NonNull String recipeName);
 
+    @NonNull
     List<BuildPlugin> findAllBuildPluginsByRecipeNameAndBuildTool(@NonNull String recipeName, @NonNull BuildTool buildTool);
 
+    @NonNull
     Optional<Properties> findMavenBuildPropertiesByRecipeName(@NonNull String recipeName);
 
 }

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/options/GenericOptions.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/options/GenericOptions.java
@@ -15,8 +15,8 @@
  */
 package io.micronaut.projectgen.core.options;
 
-import io.micronaut.core.annotation.NonNull;
-import io.micronaut.core.annotation.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.projectgen.core.buildtools.BuildTool;
@@ -63,20 +63,22 @@ public record GenericOptions(@NonNull String name,
                              @Nullable TestFramework testFramework) implements Options {
     @Override
     public Options withoutFeatures() {
-        return GenericOptionsBuilder.builder()
-            .name(this.name())
-            .configurationFormat(this.configurationFormat())
-            .operatingSystem(this.operatingSystem())
-            .template(this.template())
-            .buildTools(this.buildTools())
-            .gradleDsl(this.gradleDsl())
-            .group(this.group())
-            .artifact(this.artifact())
-            .java(this.java())
-            .packageName(this.packageName())
-            .packaging(this.packaging())
-            .testFramework(this.testFramework())
-            .build();
+        return new GenericOptions(
+            this.name(),
+            this.version(),
+            this.operatingSystem(),
+            this.template(),
+            this.language(),
+            this.buildTools(),
+            this.configurationFormat(),
+            this.gradleDsl(),
+            this.group(),
+            this.artifact(),
+            this.java(),
+            this.packageName(),
+            this.packaging(),
+            Collections.emptyList(),
+            this.testFramework());
     }
 
     @Override
@@ -90,7 +92,7 @@ public record GenericOptions(@NonNull String name,
     @Override
     public String group() {
         if (StringUtils.isEmpty(this.group)) {
-            return packageName();
+            return StringUtils.isEmpty(packageName()) ? "example" : packageName();
         }
         return this.group;
     }

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/options/GenericOptions.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/options/GenericOptions.java
@@ -61,6 +61,27 @@ public record GenericOptions(@NonNull String name,
                              @Nullable Packaging packaging,
                              @Nullable List<String> features,
                              @Nullable TestFramework testFramework) implements Options {
+
+    @Override
+    public String template() {
+        return StringUtils.isEmpty(this.template) ? "DEFAULT" : this.template;
+    }
+
+    @Override
+    public Language language() {
+        return this.language == null ? Language.JAVA : this.language;
+    }
+
+    @Override
+    public JdkVersion java() {
+        return this.java == null ? JdkVersion.JDK_25 : this.java;
+    }
+
+    @Override
+    public TestFramework testFramework() {
+        return this.testFramework == null ? TestFramework.DEFAULT_OPTION : this.testFramework;
+    }
+
     @Override
     public Options withoutFeatures() {
         return new GenericOptions(
@@ -79,6 +100,11 @@ public record GenericOptions(@NonNull String name,
             this.packaging(),
             Collections.emptyList(),
             this.testFramework());
+    }
+
+    @Override
+    public String packageName() {
+        return StringUtils.isEmpty(this.packageName) ? "example" : this.packageName;
     }
 
     @Override

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/options/JdkDistribution.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/options/JdkDistribution.java
@@ -15,7 +15,7 @@
  */
 package io.micronaut.projectgen.core.options;
 
-import io.micronaut.core.annotation.NonNull;
+import org.jspecify.annotations.NonNull;
 
 /**
  * @see <a href="https://github.com/actions/setup-java#supported-distributions">Github Supported Distributions</a>
@@ -43,13 +43,11 @@ public enum JdkDistribution {
         this.description = description;
     }
 
-    @NonNull
-    public String distribution() {
+    public @NonNull String distribution() {
         return distribution;
     }
 
-    @NonNull
-    public String description() {
+    public @NonNull String description() {
         return description;
     }
 }

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/options/JdkVersion.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/options/JdkVersion.java
@@ -17,7 +17,7 @@ package io.micronaut.projectgen.core.options;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-import io.micronaut.core.annotation.NonNull;
+import org.jspecify.annotations.NonNull;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.serde.annotation.Serdeable;
 

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/options/Language.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/options/Language.java
@@ -15,7 +15,8 @@
  */
 package io.micronaut.projectgen.core.options;
 
-import io.micronaut.core.annotation.NonNull;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import io.micronaut.projectgen.core.feature.Feature;
 import io.micronaut.projectgen.core.feature.LanguageSpecificFeature;
 
@@ -74,6 +75,7 @@ public enum Language {
         return getTestSrcDir() + path + "." + getExtension();
     }
 
+    @Nullable
     public static Language infer(Set<Feature> features) {
         return features.stream()
                 .filter(LanguageSpecificFeature.class::isInstance)
@@ -97,8 +99,7 @@ public enum Language {
         return getName();
     }
 
-    @NonNull
-    public String getName() {
+    public @NonNull String getName() {
         return name().toLowerCase(Locale.ENGLISH);
     }
 }

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/options/Options.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/options/Options.java
@@ -34,10 +34,10 @@ public interface Options {
     @Nullable
     OperatingSystem operatingSystem();
 
-    @Nullable
+    @NonNull
     String template();
 
-    @Nullable
+    @NonNull
     Language language();
 
     List<BuildTool> buildTools();
@@ -51,13 +51,13 @@ public interface Options {
     @Nullable
     String group();
 
-    @Nullable
+    @NonNull
     String artifact();
 
-    @Nullable
+    @NonNull
     JdkVersion java();
 
-    @Nullable
+    @NonNull
     @JavaPackageName
     String packageName();
 
@@ -70,7 +70,7 @@ public interface Options {
     @NonNull
     List<String> features();
 
-    @Nullable
+    @NonNull
     TestFramework testFramework();
 
     @Nullable

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/options/Options.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/options/Options.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.projectgen.core.options;
 
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import io.micronaut.projectgen.core.buildtools.BuildTool;
 import io.micronaut.projectgen.core.buildtools.gradle.GradleDsl;
@@ -27,6 +28,7 @@ import java.util.List;
  * Project creation options.
 */
 public interface Options {
+    @NonNull
     String name();
 
     @Nullable
@@ -65,6 +67,7 @@ public interface Options {
     @Nullable
     Packaging packaging();
 
+    @NonNull
     List<String> features();
 
     @Nullable

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/options/Options.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/options/Options.java
@@ -15,8 +15,7 @@
  */
 package io.micronaut.projectgen.core.options;
 
-import io.micronaut.core.annotation.NonNull;
-import io.micronaut.core.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import io.micronaut.projectgen.core.buildtools.BuildTool;
 import io.micronaut.projectgen.core.buildtools.gradle.GradleDsl;
 import io.micronaut.projectgen.core.buildtools.maven.Packaging;
@@ -28,7 +27,6 @@ import java.util.List;
  * Project creation options.
 */
 public interface Options {
-    @NonNull
     String name();
 
     @Nullable
@@ -40,7 +38,6 @@ public interface Options {
     @Nullable
     Language language();
 
-    @Nullable
     List<BuildTool> buildTools();
 
     @Nullable
@@ -68,15 +65,15 @@ public interface Options {
     @Nullable
     Packaging packaging();
 
-    @NonNull
     List<String> features();
 
     @Nullable
     TestFramework testFramework();
 
+    @Nullable
     default BuildTool getBuildTool() {
         List<BuildTool> tools = buildTools();
-        return tools.isEmpty() ? null : tools.get(0);
+        return tools == null || tools.isEmpty() ? null : tools.get(0);
     }
 
     Options withoutFeatures();

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/options/TestFramework.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/options/TestFramework.java
@@ -15,7 +15,7 @@
  */
 package io.micronaut.projectgen.core.options;
 
-import io.micronaut.core.annotation.NonNull;
+import org.jspecify.annotations.NonNull;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -52,8 +52,7 @@ public enum TestFramework {
         return this.name().toLowerCase();
     }
 
-    @NonNull
-    public String getName() {
+    public @NonNull String getName() {
         return name().toLowerCase(Locale.ENGLISH);
     }
 

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/template/DefaultTemplate.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/template/DefaultTemplate.java
@@ -15,7 +15,7 @@
  */
 package io.micronaut.projectgen.core.template;
 
-import io.micronaut.core.annotation.NonNull;
+import org.jspecify.annotations.NonNull;
 
 public abstract class DefaultTemplate implements Template {
 

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/template/DefaultTemplateRenderer.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/template/DefaultTemplateRenderer.java
@@ -36,6 +36,7 @@ public class DefaultTemplateRenderer implements TemplateRenderer {
         this.outputHandler = outputHandler;
     }
 
+    @Override
     public RenderResult render(Template template, boolean force) {
         String path = replaceVariables(template.getPath(), replacements);
         if (outputHandler.exists(path) && !force) {

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/template/PropertiesTemplate.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/template/PropertiesTemplate.java
@@ -75,16 +75,19 @@ public class PropertiesTemplate extends DefaultTemplate {
             return Collections.list(keys());
         }
 
+        @Override
         public Enumeration<Object> keys() {
             return Collections.enumeration(keys);
         }
 
+        @Override
         public Object put(Object key, Object value) {
             keys.add(key);
             return super.put(key, value);
         }
 
         // Override Properties `store` method to avoid printing date
+        @Override
         public void store(OutputStream out, String comments)
             throws IOException {
             store0(new BufferedWriter(new OutputStreamWriter(out, StandardCharsets.ISO_8859_1)),

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/template/RenderResult.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/template/RenderResult.java
@@ -15,6 +15,8 @@
  */
 package io.micronaut.projectgen.core.template;
 
+import org.jspecify.annotations.Nullable;
+
 public interface RenderResult {
 
     boolean isSuccess();
@@ -23,6 +25,7 @@ public interface RenderResult {
 
     String getPath();
 
+    @Nullable
     Exception getError();
 
     static RenderResult skipped(String path) {
@@ -43,6 +46,7 @@ public interface RenderResult {
             }
 
             @Override
+            @Nullable
             public Exception getError() {
                 return null;
             }
@@ -67,6 +71,7 @@ public interface RenderResult {
             }
 
             @Override
+            @Nullable
             public Exception getError() {
                 return null;
             }

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/template/TomlStringOutputUtil.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/template/TomlStringOutputUtil.java
@@ -15,6 +15,8 @@
  */
 package io.micronaut.projectgen.core.template;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * From jackson-dataformats-text
  */
@@ -121,7 +123,7 @@ class TomlStringOutputUtil {
      * Get the basic string escape sequence for a character, or {@code null} if the character does not need to be
      * escaped.
      */
-    static String getBasicStringEscape(char c) {
+    static @Nullable String getBasicStringEscape(char c) {
         switch (c) {
             case '\b':
                 return "\\b";

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/template/URLTemplate.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/template/URLTemplate.java
@@ -48,6 +48,7 @@ public class URLTemplate extends DefaultTemplate {
         }
     }
 
+    @Override
     public boolean isExecutable() {
         return executable;
     }

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/utils/NameUtils.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/utils/NameUtils.java
@@ -19,6 +19,7 @@ import io.micronaut.core.util.StringUtils;
 import io.micronaut.projectgen.core.generator.Project;
 import io.micronaut.projectgen.core.generator.ProjectIdentifier;
 import io.micronaut.projectgen.core.options.Options;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -428,7 +429,7 @@ public final class NameUtils {
      * @param clazz The class to convert
      * @return The script name representation
      */
-    public static String getScriptName(Class<?> clazz) {
+    public static @Nullable String getScriptName(@Nullable Class<?> clazz) {
         return clazz == null ? null : getScriptName(clazz.getName());
     }
 
@@ -439,7 +440,7 @@ public final class NameUtils {
      * @param name The class name to convert.
      * @return The script name representation.
      */
-    public static String getScriptName(String name) {
+    public static @Nullable String getScriptName(@Nullable String name) {
         if (name == null) {
             return null;
         }
@@ -472,7 +473,7 @@ public final class NameUtils {
      * @throws IllegalArgumentException if the given descriptor name is
      *                                  not valid, i.e. if it doesn't end with "GrailsPlugin.groovy".
      */
-    public static String getPluginName(String descriptorName) {
+    public static @Nullable String getPluginName(@Nullable String descriptorName) {
         if (descriptorName == null || descriptorName.length() == 0) {
             return descriptorName;
         }
@@ -613,7 +614,7 @@ public final class NameUtils {
      * @param suffix The suffix to append to the name.
      * @return The property name convention
      */
-    public static String getPropertyNameConvention(Object object, String suffix) {
+    public static @Nullable String getPropertyNameConvention(@Nullable Object object, String suffix) {
         if (object != null) {
             Class<?> type = object.getClass();
             if (type.isArray()) {
@@ -659,7 +660,7 @@ public final class NameUtils {
      * @param getterName The getter name
      * @return The property name equivalent
      */
-    public static String getPropertyForGetter(String getterName) {
+    public static @Nullable String getPropertyForGetter(@Nullable String getterName) {
         return getPropertyForGetter(getterName, boolean.class);
     }
 
@@ -671,7 +672,7 @@ public final class NameUtils {
      * @param returnType The type the method returns
      * @return The property name equivalent
      */
-    public static String getPropertyForGetter(String getterName, Class returnType) {
+    public static @Nullable String getPropertyForGetter(@Nullable String getterName, Class returnType) {
         if (getterName == null || getterName.length() == 0) {
             return null;
         }
@@ -694,7 +695,7 @@ public final class NameUtils {
      * @param suffix The suffix to inspect
      * @return The property name or null
      */
-    static String convertValidPropertyMethodSuffix(String suffix) {
+    static @Nullable String convertValidPropertyMethodSuffix(String suffix) {
         if (suffix.length() == 0) {
             return null;
         }
@@ -821,7 +822,7 @@ public final class NameUtils {
      * @param setterName The setter name, must be null or empty or a valid identifier name
      * @return The property name equivalent
      */
-    public static String getPropertyForSetter(String setterName) {
+    public static @Nullable String getPropertyForSetter(@Nullable String setterName) {
         if (setterName == null || setterName.length() == 0) {
             return null;
         }

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/utils/OperatingSystemUtils.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/utils/OperatingSystemUtils.java
@@ -15,7 +15,7 @@
  */
 package io.micronaut.projectgen.core.utils;
 
-import io.micronaut.core.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import io.micronaut.projectgen.core.options.OperatingSystem;
 
 import static io.micronaut.projectgen.core.options.OperatingSystem.LINUX;

--- a/projectgen-core/src/main/java/io/micronaut/projectgen/core/validation/JavaPackageNameValidator.java
+++ b/projectgen-core/src/main/java/io/micronaut/projectgen/core/validation/JavaPackageNameValidator.java
@@ -17,8 +17,8 @@ package io.micronaut.projectgen.core.validation;
 
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.Introspected;
-import io.micronaut.core.annotation.NonNull;
-import io.micronaut.core.annotation.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.validation.validator.constraints.ConstraintValidator;
 import io.micronaut.validation.validator.constraints.ConstraintValidatorContext;

--- a/projectgen-core/src/main/resources/META-INF/native-image/io.micronaut.projectgen/micronaut-projectgen-core/reflect-config.json
+++ b/projectgen-core/src/main/resources/META-INF/native-image/io.micronaut.projectgen/micronaut-projectgen-core/reflect-config.json
@@ -1,0 +1,102 @@
+[
+  {
+    "condition": { "typeReachable": "com.fizzed.rocker.runtime.PlainTextUnloadedClassLoader" },
+    "name": "io.micronaut.projectgen.core.template.genericBuildGradle$PlainText",
+    "allDeclaredFields": true
+  },
+  {
+    "condition": { "typeReachable": "com.fizzed.rocker.runtime.PlainTextUnloadedClassLoader" },
+    "name": "io.micronaut.projectgen.core.template.genericPom$PlainText",
+    "allDeclaredFields": true
+  },
+  {
+    "condition": { "typeReachable": "com.fizzed.rocker.runtime.PlainTextUnloadedClassLoader" },
+    "name": "io.micronaut.projectgen.core.template.gitignore$PlainText",
+    "allDeclaredFields": true
+  },
+  {
+    "condition": { "typeReachable": "com.fizzed.rocker.runtime.PlainTextUnloadedClassLoader" },
+    "name": "io.micronaut.projectgen.core.template.gradleProperties$PlainText",
+    "allDeclaredFields": true
+  },
+  {
+    "condition": { "typeReachable": "com.fizzed.rocker.runtime.PlainTextUnloadedClassLoader" },
+    "name": "io.micronaut.projectgen.core.template.licenseApache20$PlainText",
+    "allDeclaredFields": true
+  },
+  {
+    "condition": { "typeReachable": "com.fizzed.rocker.runtime.PlainTextUnloadedClassLoader" },
+    "name": "io.micronaut.projectgen.core.template.markdownLink$PlainText",
+    "allDeclaredFields": true
+  },
+  {
+    "condition": { "typeReachable": "com.fizzed.rocker.runtime.PlainTextUnloadedClassLoader" },
+    "name": "io.micronaut.projectgen.core.template.mavenCompilerPlugin$PlainText",
+    "allDeclaredFields": true
+  },
+  {
+    "condition": { "typeReachable": "com.fizzed.rocker.runtime.PlainTextUnloadedClassLoader" },
+    "name": "io.micronaut.projectgen.core.template.mavenDependency$PlainText",
+    "allDeclaredFields": true
+  },
+  {
+    "condition": { "typeReachable": "com.fizzed.rocker.runtime.PlainTextUnloadedClassLoader" },
+    "name": "io.micronaut.projectgen.core.template.mavenPlugin$PlainText",
+    "allDeclaredFields": true
+  },
+  {
+    "condition": { "typeReachable": "com.fizzed.rocker.runtime.PlainTextUnloadedClassLoader" },
+    "name": "io.micronaut.projectgen.core.template.mavenProperties$PlainText",
+    "allDeclaredFields": true
+  },
+  {
+    "condition": { "typeReachable": "com.fizzed.rocker.runtime.PlainTextUnloadedClassLoader" },
+    "name": "io.micronaut.projectgen.core.template.mavenPublishGradlePlugin$PlainText",
+    "allDeclaredFields": true
+  },
+  {
+    "condition": { "typeReachable": "com.fizzed.rocker.runtime.PlainTextUnloadedClassLoader" },
+    "name": "io.micronaut.projectgen.core.template.mavenRepository$PlainText",
+    "allDeclaredFields": true
+  },
+  {
+    "condition": { "typeReachable": "com.fizzed.rocker.runtime.PlainTextUnloadedClassLoader" },
+    "name": "io.micronaut.projectgen.core.template.parentPom$PlainText",
+    "allDeclaredFields": true
+  },
+  {
+    "condition": { "typeReachable": "com.fizzed.rocker.runtime.PlainTextUnloadedClassLoader" },
+    "name": "io.micronaut.projectgen.core.template.profile$PlainText",
+    "allDeclaredFields": true
+  },
+  {
+    "condition": { "typeReachable": "com.fizzed.rocker.runtime.PlainTextUnloadedClassLoader" },
+    "name": "io.micronaut.projectgen.core.template.settingsGradle$PlainText",
+    "allDeclaredFields": true
+  },
+  {
+    "condition": { "typeReachable": "com.fizzed.rocker.runtime.PlainTextUnloadedClassLoader" },
+    "name": "io.micronaut.projectgen.core.template.settingsPluginManagement$PlainText",
+    "allDeclaredFields": true
+  },
+  {
+    "condition": { "typeReachable": "com.fizzed.rocker.runtime.PlainTextUnloadedClassLoader" },
+    "name": "io.micronaut.projectgen.core.template.signingGradlePlugin$PlainText",
+    "allDeclaredFields": true
+  },
+  {
+    "condition": { "typeReachable": "com.fizzed.rocker.runtime.PlainTextUnloadedClassLoader" },
+    "name": "io.micronaut.projectgen.core.template.spotlessGradlePlugin$PlainText",
+    "allDeclaredFields": true
+  },
+  {
+    "condition": { "typeReachable": "com.fizzed.rocker.runtime.PlainTextUnloadedClassLoader" },
+    "name": "io.micronaut.projectgen.core.template.spotlesslicensejava$PlainText",
+    "allDeclaredFields": true
+  },
+  {
+    "condition": { "typeReachable": "com.fizzed.rocker.runtime.PlainTextUnloadedClassLoader" },
+    "name": "io.micronaut.projectgen.core.template.substitutions$PlainText",
+    "allDeclaredFields": true
+  }
+]

--- a/projectgen-core/src/main/resources/META-INF/native-image/io.micronaut.projectgen/micronaut-projectgen-core/resource-config.json
+++ b/projectgen-core/src/main/resources/META-INF/native-image/io.micronaut.projectgen/micronaut-projectgen-core/resource-config.json
@@ -1,0 +1,9 @@
+{
+  "resources": {
+    "includes": [
+      {
+        "pattern": "io/micronaut/projectgen/core/template/.*\\$PlainText\\.class$"
+      }
+    ]
+  }
+}

--- a/projectgen-http-server/src/main/java/io/micronaut/projectgen/http/server/DefaultOptionsBuilder.java
+++ b/projectgen-http-server/src/main/java/io/micronaut/projectgen/http/server/DefaultOptionsBuilder.java
@@ -54,7 +54,7 @@ public class DefaultOptionsBuilder implements OptionsBuilder {
     protected  static final String VERSION = "version";
 
     @Override
-    public Options createOptions(Map<String, Object> form) {
+    public Options createOptions(@Nullable Map<String, Object> form) {
         return createOptionsBuilder(form).build();
     }
 
@@ -100,8 +100,8 @@ public class DefaultOptionsBuilder implements OptionsBuilder {
         List<String> result = new ArrayList<>();
         if (resultObj instanceof List<?>) {
             for (Object featureObj : (List<?>) resultObj) {
-                if (featureObj instanceof String feature) {
-                    result.add(feature);
+                if (featureObj != null) {
+                    result.add(featureObj.toString());
                 }
             }
         } else if (resultObj instanceof String feature) {

--- a/projectgen-http-server/src/test/java/io/micronaut/projectgen/http/server/DefaultOptionsBuilderTest.java
+++ b/projectgen-http-server/src/test/java/io/micronaut/projectgen/http/server/DefaultOptionsBuilderTest.java
@@ -40,5 +40,14 @@ class DefaultOptionsBuilderTest {
         assertEquals(GradleDsl.GROOVY, options.gradleDsl());
         assertEquals(Language.GROOVY, options.language());
         assertEquals(TestFramework.SPOCK, options.testFramework());
+
+        form = Map.of(
+            "name", "enum-list-demo",
+            "build", List.of(BuildTool.GRADLE, BuildTool.MAVEN),
+            "features", List.of("geb-core"));
+        options = builder.createOptions(form);
+
+        assertEquals(List.of(BuildTool.GRADLE, BuildTool.MAVEN), options.buildTools());
+        assertEquals(List.of("geb-core"), options.features());
     }
 }

--- a/projectgen-micronaut/build.gradle.kts
+++ b/projectgen-micronaut/build.gradle.kts
@@ -1,3 +1,5 @@
+import net.ltgt.gradle.errorprone.errorprone
+
 plugins {
     id("io.micronaut.build.internal.projectgen-module")
     id("nu.studer.rocker") version "3.3.1"
@@ -33,7 +35,6 @@ spotless {
         targetExclude("src/**/*.rocker.raw")
     }
 }
-
-micronautNullAway {
-    disableOnProjectNameContains.add("projectgen-micronaut")
+tasks.withType<JavaCompile>().configureEach {
+    options.errorprone.option("NullAway:UnannotatedSubPackages", "io.micronaut.projectgen.micronaut.template")
 }

--- a/projectgen-micronaut/build.gradle.kts
+++ b/projectgen-micronaut/build.gradle.kts
@@ -33,3 +33,7 @@ spotless {
         targetExclude("src/**/*.rocker.raw")
     }
 }
+
+micronautNullAway {
+    disableOnProjectNameContains.add("projectgen-micronaut")
+}

--- a/projectgen-micronaut/src/main/java/io/micronaut/projectgen/micronaut/ApplicationType.java
+++ b/projectgen-micronaut/src/main/java/io/micronaut/projectgen/micronaut/ApplicationType.java
@@ -45,6 +45,9 @@ public enum ApplicationType implements Named {
     }
 
     public static ApplicationType of(@Nullable String template) {
+        if (template == null) {
+            return DEFAULT_OPTION;
+        }
         for (ApplicationType type : values()) {
             if (template.equalsIgnoreCase(type.toString())) {
                 return type;

--- a/projectgen-micronaut/src/main/java/io/micronaut/projectgen/micronaut/ApplicationTypeFeature.java
+++ b/projectgen-micronaut/src/main/java/io/micronaut/projectgen/micronaut/ApplicationTypeFeature.java
@@ -62,8 +62,7 @@ public abstract class ApplicationTypeFeature implements DefaultFeature, Requires
         featureContext.addFeatureIfNotPresent(MicronautCli.class, micronautCli);
         featureContext.addFeatureIfNotPresent(GitIgnore.class, gitIgnore);
         featureContext.addFeatureIfNotPresent(LoggingFeature.class, logback);
-        if (featureContext.getOptions().testFramework() == null
-            || featureContext.getOptions().testFramework() == TestFramework.JUNIT) {
+        if (featureContext.getOptions().testFramework() == TestFramework.JUNIT) {
             featureContext.addFeatureIfNotPresent(MicronautTestJunit5.class, micronautTestJunit5);
         } else if (featureContext.getOptions().testFramework() == TestFramework.SPOCK) {
             featureContext.addFeatureIfNotPresent(MicronautTestSpock.class, micronautTestSpock);

--- a/projectgen-micronaut/src/main/java/io/micronaut/projectgen/micronaut/LanguageUtils.java
+++ b/projectgen-micronaut/src/main/java/io/micronaut/projectgen/micronaut/LanguageUtils.java
@@ -32,7 +32,7 @@ public final class LanguageUtils {
     @NonNull
     public LanguageDefaults languageDefaultsByLanguage(@NonNull Language language) {
         return switch (language) {
-            case PYTHON -> null;
+            case PYTHON -> throw new IllegalArgumentException("Python is not supported");
             case JAVA -> new LanguageDefaults(TestFramework.JUNIT, BuildTool.GRADLE, GradleDsl.KOTLIN);
             case GROOVY -> new LanguageDefaults(TestFramework.SPOCK, BuildTool.GRADLE, GradleDsl.GROOVY);
             case KOTLIN -> new LanguageDefaults(TestFramework.KOTEST, BuildTool.GRADLE, GradleDsl.KOTLIN);

--- a/projectgen-micronaut/src/main/java/io/micronaut/projectgen/micronaut/features/cli/MicronautCliConfig.java
+++ b/projectgen-micronaut/src/main/java/io/micronaut/projectgen/micronaut/features/cli/MicronautCliConfig.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.projectgen.micronaut.features.cli;
 
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -23,12 +24,12 @@ import java.util.List;
  * test framework, source language, selected features, build tool, and the default package name.
  */
 public class MicronautCliConfig {
-    private String applicationType;
-    private String testFramework;
-    private String defaultPackage;
-    private String sourceLanguage;
-    private List<String> features;
-    private String buildTool;
+    private String applicationType = "";
+    private String testFramework = "";
+    private String defaultPackage = "";
+    private String sourceLanguage = "";
+    private List<String> features = Collections.emptyList();
+    private String buildTool = "";
 
     /**
      * Returns the application type.

--- a/projectgen-micronaut/src/main/java/io/micronaut/projectgen/micronaut/features/logging/Slf4jJulBridge.java
+++ b/projectgen-micronaut/src/main/java/io/micronaut/projectgen/micronaut/features/logging/Slf4jJulBridge.java
@@ -16,6 +16,7 @@
 package io.micronaut.projectgen.micronaut.features.logging;
 
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.projectgen.core.generator.GeneratorContext;
 import io.micronaut.projectgen.core.openrewrite.OpenRewriteFeature;
 import jakarta.inject.Singleton;
@@ -56,7 +57,7 @@ public class Slf4jJulBridge implements OpenRewriteFeature {
     }
 
     @Override
-    public String getThirdPartyDocumentation(GeneratorContext generatorContext) {
+    public String getThirdPartyDocumentation(@Nullable GeneratorContext generatorContext) {
         return "https://www.slf4j.org/legacy.html#jul-to-slf4jBridge";
     }
 

--- a/projectgen-micronaut/src/main/java/io/micronaut/projectgen/micronaut/gradle/MicronautApplicationGradlePlugin.java
+++ b/projectgen-micronaut/src/main/java/io/micronaut/projectgen/micronaut/gradle/MicronautApplicationGradlePlugin.java
@@ -16,6 +16,7 @@
 package io.micronaut.projectgen.micronaut.gradle;
 
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.projectgen.core.buildtools.BuildPlugin;
 import io.micronaut.projectgen.core.buildtools.BuildTool;
@@ -58,21 +59,33 @@ public class MicronautApplicationGradlePlugin {
 
         private String id = APPLICATION;
         private GradleDsl dsl = GradleDsl.GROOVY;
+        @Nullable
         private String javaVersion;
+        @Nullable
         private String runtime;
+        @Nullable
         private String testRuntime;
+        @Nullable
         private String lambdaRuntimeMainClass;
+        @Nullable
         private String aotVersion;
+        @Nullable
         private Dockerfile dockerfileNative;
+        @Nullable
         private Dockerfile dockerfile;
+        @Nullable
         private List<String> dockerBuildImages;
+        @Nullable
         private List<String> dockerBuildNativeImages;
+        @Nullable
         private List<String> additionalTestResourceModules;
+        @Nullable
         private Map<String, String> aotKeys;
+        @Nullable
         private Set<String> ignoredAutomaticDependencies;
-        private BuildTool buildTool;
+        private BuildTool buildTool = BuildTool.GRADLE;
         private boolean incremental;
-        private String packageName;
+        private String packageName = "example";
         private boolean sharedTestResources;
 
         public Builder buildTool(BuildTool buildTool) {

--- a/projectgen-micronaut/src/main/java/io/micronaut/projectgen/micronaut/gradle/MicronautApplicationGradlePluginFeature.java
+++ b/projectgen-micronaut/src/main/java/io/micronaut/projectgen/micronaut/gradle/MicronautApplicationGradlePluginFeature.java
@@ -61,7 +61,7 @@ public class MicronautApplicationGradlePluginFeature implements BuildPluginFeatu
     public void apply(GeneratorContext generatorContext) {
         Coordinate coordinate = coordinateResolver.resolve(ARTIFACT_ID_MICRONAUT_PARENT).orElseThrow();
         ModuleContext module = generatorContext.getRootModule();
-        module.buildProperties().put(PROPERTY_MICRONAUT_VERSION, coordinate.getVersion());
+        module.buildProperties().put(PROPERTY_MICRONAUT_VERSION, java.util.Objects.requireNonNull(coordinate.getVersion()));
         module.addBuildPlugin(micronautApplicationGradlePlugin(generatorContext));
     }
 

--- a/projectgen-micronaut/src/main/java/io/micronaut/projectgen/micronaut/maven/MicronautParentPomFeature.java
+++ b/projectgen-micronaut/src/main/java/io/micronaut/projectgen/micronaut/maven/MicronautParentPomFeature.java
@@ -53,13 +53,11 @@ public class MicronautParentPomFeature implements ParentPomFeature {
     public void apply(GeneratorContext generatorContext) {
         ModuleContext module = generatorContext.getRootModule();
         if (OptionUtils.hasMavenBuildTool(generatorContext.getOptions())) {
-            if (generatorContext.getOptions().java() != null) {
-                String javaVersion = generatorContext.getOptions().java().asString();
-                module.buildProperties().put(PROPERTY_JDK_VERSION, javaVersion);
-                module.buildProperties().put("release.version", javaVersion);
-            }
+            String javaVersion = generatorContext.getOptions().java().asString();
+            module.buildProperties().put(PROPERTY_JDK_VERSION, javaVersion);
+            module.buildProperties().put("release.version", javaVersion);
             coordinateResolver.resolve(ARTIFACT_ID_MICRONAUT_PARENT).ifPresent(coordinate ->
-                module.buildProperties().put(PROPERTY_MICRONAUT_VERSION, coordinate.getVersion()));
+                module.buildProperties().put(PROPERTY_MICRONAUT_VERSION, java.util.Objects.requireNonNull(coordinate.getVersion())));
             module.moduleAttributes().setParentPom(getParentPom());
         }
     }

--- a/projectgen-micronaut/src/main/java/io/micronaut/starter/buildtools/RequiresMavenLocal.java
+++ b/projectgen-micronaut/src/main/java/io/micronaut/starter/buildtools/RequiresMavenLocal.java
@@ -27,6 +27,7 @@ import java.util.List;
  * Marker interface for a feature which requires {@link MavenLocal} repository.
  */
 public interface RequiresMavenLocal extends RequiresRepository {
+    @Override
     @NonNull
     default List<Repository> getRepositories() {
         return Collections.singletonList(new MavenLocal());

--- a/projectgen-micronaut/src/main/java/io/micronaut/starter/client/github/v3/GitHubRepository.java
+++ b/projectgen-micronaut/src/main/java/io/micronaut/starter/client/github/v3/GitHubRepository.java
@@ -31,8 +31,11 @@ import io.micronaut.core.annotation.Nullable;
 public class GitHubRepository {
     private final String name;
     private final String description;
+    @Nullable
     private final String url;
+    @Nullable
     private final String htmlUrl;
+    @Nullable
     private final String cloneUrl;
 
     public GitHubRepository(String name, String description) {
@@ -70,6 +73,7 @@ public class GitHubRepository {
     /**
      * @return the clone URL of the repository
      */
+    @Nullable
     public String getCloneUrl() {
         return cloneUrl;
     }
@@ -77,6 +81,7 @@ public class GitHubRepository {
     /**
      * @return the URL of the repository
      */
+    @Nullable
     public String getUrl() {
         return url;
     }
@@ -84,6 +89,7 @@ public class GitHubRepository {
     /**
      * @return the HTML URL of the repository
      */
+    @Nullable
     public String getHtmlUrl() {
         return htmlUrl;
     }

--- a/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/Category.java
+++ b/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/Category.java
@@ -21,7 +21,7 @@ package io.micronaut.starter.feature;
  * @author Álvaro Sánchez-Mariscal
  * @since 2.0.0
  */
-public class Category {
+public final class Category {
     public static final String API = "API";
     public static final String BPM = "BPM";
     public static final String CACHE = "Cache";

--- a/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/CommunityFeature.java
+++ b/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/CommunityFeature.java
@@ -28,6 +28,7 @@ import io.micronaut.projectgen.core.feature.Feature;
  * @since 1.0
  */
 public interface CommunityFeature extends Feature {
+    @Override
     @NonNull
     default String getName() {
         return getCommunityContributor().toLowerCase() + "-" + getCommunityFeatureName();

--- a/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/agorapulse/console/Console.java
+++ b/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/agorapulse/console/Console.java
@@ -124,7 +124,7 @@ public class Console implements AgoraPulseFeature {
     private void addKotlinScriptingDependency(GeneratorContext generatorContext) {
         Coordinate coordinate = generatorContext.resolveCoordinate("kotlin-bom");
         ModuleContext module = generatorContext.getRootModule();
-        module.buildProperties().put("kotlinVersion", coordinate.getVersion());
+        module.buildProperties().put("kotlinVersion", java.util.Objects.requireNonNull(coordinate.getVersion()));
         Dependency.Builder kotlin = Dependency.builder()
             .groupId("org.jetbrains.kotlin")
             .compile()

--- a/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/agorapulse/gru/GruHttp.java
+++ b/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/agorapulse/gru/GruHttp.java
@@ -18,7 +18,6 @@ package io.micronaut.starter.feature.agorapulse.gru;
 import com.fizzed.rocker.RockerModel;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.NonNull;
-import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.projectgen.core.generator.ModuleContext;
 import io.micronaut.projectgen.core.options.Options;
@@ -153,7 +152,6 @@ public class GruHttp implements AgoraPulseFeature {
     }
 
     @Override
-    @Nullable
     public String getDescription() {
         return "Gru is HTTP interaction testing framework with out-of-box support for Micronaut";
     }

--- a/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/agorapulse/permissions/Permissions.java
+++ b/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/agorapulse/permissions/Permissions.java
@@ -18,7 +18,6 @@ package io.micronaut.starter.feature.agorapulse.permissions;
 import com.fizzed.rocker.RockerModel;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.NonNull;
-import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.projectgen.core.generator.ModuleContext;
 import io.micronaut.projectgen.core.generator.GeneratorContext;
@@ -89,7 +88,6 @@ public class Permissions implements AgoraPulseFeature {
     }
 
     @Override
-    @Nullable
     public String getDescription() {
         return "Micronaut Permissions is a lightweight library to declare object level permissions in Micronaut";
     }

--- a/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/agorapulse/slack/Slack.java
+++ b/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/agorapulse/slack/Slack.java
@@ -18,7 +18,6 @@ package io.micronaut.starter.feature.agorapulse.slack;
 import com.fizzed.rocker.RockerModel;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.NonNull;
-import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.projectgen.core.generator.ModuleContext;
 import io.micronaut.projectgen.core.options.Options;
@@ -125,7 +124,6 @@ public class Slack implements AgoraPulseFeature {
     }
 
     @Override
-    @Nullable
     public String getDescription() {
         return "Micronaut Slack is idiomatic alternative to Bolt Micronaut library for Slack integration into the Micronaut Framework.";
     }

--- a/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/agorapulse/worker/Worker.java
+++ b/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/agorapulse/worker/Worker.java
@@ -18,7 +18,6 @@ package io.micronaut.starter.feature.agorapulse.worker;
 import com.fizzed.rocker.RockerModel;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.NonNull;
-import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.projectgen.core.generator.ModuleContext;
 import io.micronaut.projectgen.core.options.Options;
@@ -104,7 +103,6 @@ public class Worker implements AgoraPulseFeature {
     }
 
     @Override
-    @Nullable
     public String getDescription() {
         return "Micronaut Worker library provides advanced distributed scheduling capabilities for Micronaut";
     }

--- a/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/aws/Cdk.java
+++ b/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/aws/Cdk.java
@@ -17,6 +17,7 @@ package io.micronaut.starter.feature.aws;
 
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.projectgen.core.options.Options;
 import io.micronaut.projectgen.micronaut.ApplicationType;
@@ -50,6 +51,7 @@ public class Cdk implements MultiProjectFeature, InfrastructureAsCodeFeature {
     private final DependencyContext dependencyContext;
     //private final RepositoryResolver repositoryResolver;
     private final CoordinateResolver coordinateResolver;
+    @Nullable
     private final Dependency dependencyCdk;
 
     public Cdk(CoordinateResolver coordinateResolver,

--- a/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/awslambdacustomruntime/AwsLambdaCustomRuntime.java
+++ b/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/awslambdacustomruntime/AwsLambdaCustomRuntime.java
@@ -25,6 +25,7 @@ import io.micronaut.projectgen.core.openrewrite.OpenRewriteFeature;
 import io.micronaut.projectgen.core.options.GenericOptionsBuilder;
 import io.micronaut.projectgen.core.rocker.RockerWritable;
 import io.micronaut.projectgen.core.utils.OptionUtils;
+import io.micronaut.projectgen.core.options.TestFramework;
 import io.micronaut.projectgen.micronaut.ApplicationType;
 import io.micronaut.projectgen.core.generator.Project;
 import io.micronaut.projectgen.core.generator.GeneratorContext;
@@ -192,7 +193,7 @@ public class AwsLambdaCustomRuntime implements FunctionFeature, ApplicationFeatu
     @Override
     public List<String> getRecipes(GeneratorContext generatorContext) {
         List<String> recipes = new ArrayList<>();
-        if (generatorContext.getFeatures().testFramework().isSpock()
+        if (generatorContext.getTestFramework() == TestFramework.SPOCK
             && OptionUtils.hasGradleBuildTool(generatorContext.getOptions())) {
             // maven has this in parent pom
             recipes.add("io.micronaut.starter.feature.micronaut-function-test");

--- a/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/buildtools/GradleEnterprise.java
+++ b/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/buildtools/GradleEnterprise.java
@@ -120,8 +120,8 @@ public class GradleEnterprise implements Feature, GradleEnterpriseConfiguration 
 
     private static RockerModel extensionsRockerModel(GeneratorContext generatorContext) {
         return extensions.template(
-            generatorContext.resolveCoordinate(ARTIFACT_ID_GRADLE_ENTERPRISE_MAVEN_EXTENSION).getVersion(),
-            generatorContext.resolveCoordinate(ARTIFACT_ID_COMMON_CUSTOM_USER_DATA_MAVEN_EXTENSION).getVersion());
+            java.util.Objects.requireNonNull(generatorContext.resolveCoordinate(ARTIFACT_ID_GRADLE_ENTERPRISE_MAVEN_EXTENSION).getVersion()),
+            java.util.Objects.requireNonNull(generatorContext.resolveCoordinate(ARTIFACT_ID_COMMON_CUSTOM_USER_DATA_MAVEN_EXTENSION).getVersion()));
     }
 
     @Override

--- a/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/buildtools/KotlinSupportFeature.java
+++ b/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/buildtools/KotlinSupportFeature.java
@@ -16,6 +16,7 @@
 package io.micronaut.starter.feature.buildtools;
 
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.projectgen.core.generator.ModuleContext;
 import io.micronaut.projectgen.core.utils.OptionUtils;
 import io.micronaut.projectgen.core.generator.GeneratorContext;
@@ -84,8 +85,8 @@ public interface KotlinSupportFeature extends OneOfFeature {
             && KotlinSupportFeature.shouldApply(generatorContext.getFeatures().language(), generatorContext.getFeatures().testFramework());
     }
 
-    static boolean shouldApply(LanguageFeature languageFeature, TestFeature testFeature) {
-        return languageFeature.isKotlin() || (testFeature != null && testFeature.isKotlinTestFramework());
+    static boolean shouldApply(@Nullable LanguageFeature languageFeature, @Nullable TestFeature testFeature) {
+        return (languageFeature != null && languageFeature.isKotlin()) || (testFeature != null && testFeature.isKotlinTestFramework());
     }
 
     static boolean shouldApply(Language language, TestFramework testFramework) {

--- a/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/buildtools/MicronautBuildPlugin.java
+++ b/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/buildtools/MicronautBuildPlugin.java
@@ -46,6 +46,7 @@ import io.micronaut.starter.feature.messaging.SharedTestResourceFeature;
 import io.micronaut.starter.feature.testresources.TestResources;
 import io.micronaut.starter.feature.testresources.TestResourcesAdditionalModulesProvider;
 import io.micronaut.projectgen.core.options.JdkVersion;
+import io.micronaut.projectgen.core.options.TestFramework;
 import io.micronaut.projectgen.core.options.Options;
 import io.micronaut.starter.util.FeaturesUtils;
 import jakarta.inject.Singleton;
@@ -189,8 +190,11 @@ public class MicronautBuildPlugin implements BuildPluginFeature, DefaultFeature 
             .buildTool(generatorContext.getBuildTool())
             .incremental(true)
             .javaVersion(FeaturesUtils.getTargetJdk(generatorContext.getFeatures()))
-            .packageName(generatorContext.getProject().getPackageName())
-            .ignoredAutomaticDependencies(ignoredAutomaticDependencies(generatorContext));
+            .packageName(generatorContext.getProject().getPackageName());
+        Set<String> ignoredDependencies = ignoredAutomaticDependencies(generatorContext);
+        if (ignoredDependencies != null) {
+            builder.ignoredAutomaticDependencies(ignoredDependencies);
+        }
         generatorContext.getFeatures()
             .getFeatures()
             .stream()
@@ -266,14 +270,11 @@ public class MicronautBuildPlugin implements BuildPluginFeature, DefaultFeature 
     }
 
      private Optional<String> resolveTestRuntime(GeneratorContext generatorContext) {
-        if (generatorContext.getFeatures().testFramework() == null) {
-            return Optional.empty();
-        }
-        if (generatorContext.getFeatures().testFramework().isJunit()) {
+        if (generatorContext.getTestFramework() == TestFramework.JUNIT) {
             return Optional.of("junit5");
-        } else if (generatorContext.getFeatures().testFramework().isKotlinTestFramework()) {
+        } else if (generatorContext.getTestFramework().isKotlinTestFramework()) {
             return Optional.of("kotest5");
-        } else if (generatorContext.getFeatures().testFramework().isSpock()) {
+        } else if (generatorContext.getTestFramework() == TestFramework.SPOCK) {
             return Optional.of("spock2");
         }
 

--- a/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/buildtools/gradle/MicronautApplicationGradlePlugin.java
+++ b/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/buildtools/gradle/MicronautApplicationGradlePlugin.java
@@ -16,6 +16,7 @@
 package io.micronaut.starter.feature.buildtools.gradle;
 
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.projectgen.core.buildtools.Dockerfile;
 import io.micronaut.projectgen.core.buildtools.gradle.GradleDsl;
@@ -62,23 +63,35 @@ public final class MicronautApplicationGradlePlugin {
 
         String id = APPLICATION;
         private GradleDsl dsl = GradleDsl.GROOVY;
+        @Nullable
         private String javaVersion;
+        @Nullable
         private String runtime;
+        @Nullable
         private String testRuntime;
 
+        @Nullable
         private String lambdaRuntimeMainClass;
+        @Nullable
         private String aotVersion;
+        @Nullable
         private Dockerfile dockerfileNative;
+        @Nullable
         private Dockerfile dockerfile;
+        @Nullable
         private List<String> dockerBuildImages;
+        @Nullable
         private Map<String, String> aotKeys;
+        @Nullable
         private List<String> dockerBuildNativeImages;
+        @Nullable
         private List<String> additionalTestResourceModules;
-        private BuildTool buildTool;
+        private BuildTool buildTool = BuildTool.GRADLE;
         private boolean incremental;
-        private  String packageName;
+        private String packageName = "example";
         private boolean sharedTestResources;
 
+        @Nullable
         private Set<String> ignoredAutomaticDependencies;
 
         /**

--- a/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/buildtools/maven/Property.java
+++ b/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/buildtools/maven/Property.java
@@ -16,6 +16,7 @@
 package io.micronaut.starter.feature.buildtools.maven;
 
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
 
 import java.util.Objects;
 
@@ -99,7 +100,9 @@ public class Property {
      * Provides a fluent API for setting property name and value.
      */
     public static class Builder {
+        @Nullable
         private String name;
+        @Nullable
         private String value;
 
         /**

--- a/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/ci/workflows/gcp/GoogleCloudCiWorkflowFeature.java
+++ b/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/ci/workflows/gcp/GoogleCloudCiWorkflowFeature.java
@@ -70,7 +70,7 @@ public class GoogleCloudCiWorkflowFeature extends CIWorkflowFeature {
         return new RockerTemplate(WORKFLOW_FILENAME, cloudBuild.template(
             generatorContext.getProject().getName(),
             generatorContext.getJdkVersion(),
-            generatorContext.getOptions().getBuildTool())
+            generatorContext.getBuildTool())
         );
     }
 

--- a/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/ci/workflows/gitlab/GitlabCiWorkflowFeature.java
+++ b/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/ci/workflows/gitlab/GitlabCiWorkflowFeature.java
@@ -66,7 +66,7 @@ public class GitlabCiWorkflowFeature extends CIWorkflowFeature {
         return new RockerTemplate(WORKFLOW_FILE_NAME,
             gitlabci.template(
                 generatorContext.getProject().getName(),
-                generatorContext.getOptions().getBuildTool(),
+                generatorContext.getBuildTool(),
                 generatorContext.getJdkVersion(),
                 generatorContext.getFeatures().hasFeature(GraalVM.class))
         );

--- a/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/database/DatabaseDriverFeature.java
+++ b/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/database/DatabaseDriverFeature.java
@@ -16,6 +16,7 @@
 package io.micronaut.starter.feature.database;
 
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.projectgen.core.generator.ModuleContext;
 import io.micronaut.projectgen.core.generator.GeneratorContext;
 import io.micronaut.projectgen.core.buildtools.dependencies.Dependency;
@@ -35,6 +36,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 import static io.micronaut.starter.buildtools.dependencies.MicronautDependencyUtils.GROUP_ID_MICRONAUT_TESTRESOURCES;
@@ -49,15 +51,16 @@ import static io.micronaut.starter.buildtools.dependencies.MicronautDependencyUt
  */
 public abstract class DatabaseDriverFeature extends EaseTestingFeature implements OneOfFeature, DatabaseDriverFeatureDependencies, TestResourcesAdditionalModulesProvider {
 
+    @Nullable
     private final JdbcFeature jdbcFeature;
 
     public DatabaseDriverFeature() {
         this(null, null, null);
     }
 
-    public DatabaseDriverFeature(JdbcFeature jdbcFeature,
-        TestContainers testContainers,
-        TestResources testResources) {
+    public DatabaseDriverFeature(@Nullable JdbcFeature jdbcFeature,
+        @Nullable TestContainers testContainers,
+        @Nullable TestResources testResources) {
         super(testContainers, testResources);
         this.jdbcFeature = jdbcFeature;
     }
@@ -70,8 +73,9 @@ public abstract class DatabaseDriverFeature extends EaseTestingFeature implement
     @Override
     public void processSelectedFeatures(FeatureContext featureContext) {
         super.processSelectedFeatures(featureContext);
-        if (shouldAddJdbcFeature(featureContext)) {
-            featureContext.addFeature(jdbcFeature);
+        JdbcFeature feature = jdbcFeature;
+        if (feature != null && shouldAddJdbcFeature(featureContext)) {
+            featureContext.addFeature(feature);
         }
     }
 
@@ -79,7 +83,7 @@ public abstract class DatabaseDriverFeature extends EaseTestingFeature implement
         return !featureContext.isPresent(JdbcFeature.class)
             && !featureContext.isPresent(R2dbcFeature.class)
             && !hasHibernateReactiveWithoutMigration(featureContext)
-            && jdbcFeature != null;
+;
     }
 
     private boolean hasHibernateReactiveWithoutMigration(FeatureContext featureContext) {
@@ -93,10 +97,13 @@ public abstract class DatabaseDriverFeature extends EaseTestingFeature implement
 
     public abstract boolean embedded();
 
+    @Nullable
     public abstract String getJdbcUrl();
 
+    @Nullable
     public abstract String getR2dbcUrl();
 
+    @Nullable
     public abstract String getDriverClass();
 
     public abstract String getDefaultUser();
@@ -163,7 +170,7 @@ public abstract class DatabaseDriverFeature extends EaseTestingFeature implement
             generatorContext.getFeature(DatabaseDriverFeature.class)
                 .flatMap(DatabaseDriverFeatureDependencies::getJavaClientDependency)
                 .map(Dependency.Builder::build)
-                .ifPresent(driver -> dependencies.add(new MavenCoordinate(driver.getGroupId(), driver.getArtifactId(), null)));
+                .ifPresent(driver -> dependencies.add(new MavenCoordinate(Objects.requireNonNull(driver.getGroupId()), driver.getArtifactId(), null)));
         }
         return dependencies;
     }

--- a/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/database/HibernateReactiveFeature.java
+++ b/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/database/HibernateReactiveFeature.java
@@ -24,6 +24,7 @@ import io.micronaut.starter.feature.testresources.DbType;
 import io.micronaut.starter.feature.testresources.EaseTestingFeature;
 import io.micronaut.starter.feature.testresources.TestResources;
 
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -62,7 +63,7 @@ public abstract class HibernateReactiveFeature extends EaseTestingFeature implem
         if (!generatorContext.isFeaturePresent(TestResources.class)) {
             Optional<MigrationFeature> migrationFeature = generatorContext.getFeatures().getFeature(MigrationFeature.class);
             module.configuration().put(JPA_DEFAULT_PROPERTIES_HIBERNATE_CONNECTION_URL,
-                migrationFeature.map(f -> "${datasources.default.url}").orElse(dbFeature.getJdbcUrl()));
+                migrationFeature.map(f -> "${datasources.default.url}").orElseGet(() -> Objects.requireNonNull(dbFeature.getJdbcUrl())));
             module.configuration().put(JPA_DEFAULT_PROPERTIES_HIBERNATE_CONNECTION_USERNAME,
                 migrationFeature.map(f -> "${datasources.default.username}").orElse(dbFeature.getDefaultUser()));
             module.configuration().put(JPA_DEFAULT_PROPERTIES_HIBERNATE_CONNECTION_PASSWORD,

--- a/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/discovery/DiscoveryClient.java
+++ b/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/discovery/DiscoveryClient.java
@@ -52,7 +52,7 @@ public class DiscoveryClient implements OpenRewriteFeature {
     }
 
     /**
-     * @deprecated Use {@link DiscoveryClient(HttpClient)} instead.
+     * @deprecated Use {@link #DiscoveryClient(HttpClient)} instead.
      */
     @Deprecated
     public DiscoveryClient() {

--- a/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/function/DocumentationLink.java
+++ b/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/function/DocumentationLink.java
@@ -25,10 +25,10 @@ import io.micronaut.core.annotation.NonNull;
 @Introspected
 public class DocumentationLink {
     @NonNull
-    private String title;
+    private String title = "";
 
     @NonNull
-    private String url;
+    private String url = "";
 
     public DocumentationLink() {
     }

--- a/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/function/awslambda/AwsLambda.java
+++ b/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/function/awslambda/AwsLambda.java
@@ -24,6 +24,7 @@ import io.micronaut.projectgen.core.generator.ModuleContext;
 import io.micronaut.projectgen.core.options.GenericOptionsBuilder;
 import io.micronaut.projectgen.core.rocker.RockerWritable;
 import io.micronaut.projectgen.core.utils.OptionUtils;
+import io.micronaut.projectgen.core.options.TestFramework;
 import io.micronaut.projectgen.micronaut.ApplicationType;
 import io.micronaut.projectgen.core.generator.Project;
 import io.micronaut.projectgen.core.generator.GeneratorContext;
@@ -255,7 +256,7 @@ public class AwsLambda implements FunctionFeature, DefaultFeature, AwsCloudFeatu
             module.addDependency(DEPENDENCY_MICRONAUT_CRAC);
         }
 
-        if (generatorContext.getFeatures().testFramework().isSpock()
+        if (generatorContext.getTestFramework() == TestFramework.SPOCK
             && OptionUtils.hasGradleBuildTool(generatorContext.getOptions())) {
             // maven has this in parent pom
             module.addDependency(DEPENDENCY_MICRONAUT_FUNCTION_TEST);

--- a/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/function/azure/AbstractAzureFunction.java
+++ b/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/function/azure/AbstractAzureFunction.java
@@ -114,7 +114,7 @@ public abstract class AbstractAzureFunction extends AbstractFunctionFeature impl
                 .build());
             BuildProperties props = module.buildProperties();
             coordinateResolver.resolve(mavenPluginArtifactId)
-                .ifPresent(coordinate -> props.put("azure.functions.maven.plugin.version", coordinate.getVersion()));
+                .ifPresent(coordinate -> props.put("azure.functions.maven.plugin.version", java.util.Objects.requireNonNull(coordinate.getVersion())));
             props.put("functionAppName", project.getName());
             props.put("functionResourceGroup", "java-functions-group");
             props.put("functionAppRegion", "westus");

--- a/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/function/gcp/AbstractGoogleCloudFunction.java
+++ b/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/function/gcp/AbstractGoogleCloudFunction.java
@@ -18,6 +18,7 @@ package io.micronaut.starter.feature.function.gcp;
 import io.micronaut.projectgen.core.generator.GeneratorContext;
 import io.micronaut.projectgen.core.buildtools.dependencies.Dependency;
 import io.micronaut.projectgen.core.generator.ModuleContext;
+import io.micronaut.projectgen.core.options.TestFramework;
 import io.micronaut.projectgen.micronaut.gradle.ShadePlugin;
 import io.micronaut.starter.buildtools.dependencies.MicronautDependencyUtils;
 import io.micronaut.projectgen.core.feature.FeatureContext;
@@ -50,7 +51,7 @@ public abstract class AbstractGoogleCloudFunction extends AbstractFunctionFeatur
     public void apply(GeneratorContext generatorContext) {
         super.apply(generatorContext);
         ModuleContext module = generatorContext.getRootModule();
-        if (generatorContext.getFeatures().testFramework().isSpock()) {
+        if (generatorContext.getTestFramework() == TestFramework.SPOCK) {
             module.addDependency(DEPENDENCY_MICRONAUT_SERVLET_CORE);
         }
     }

--- a/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/github/workflows/Secret.java
+++ b/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/github/workflows/Secret.java
@@ -15,6 +15,8 @@
  */
 package io.micronaut.starter.feature.github.workflows;
 
+import io.micronaut.core.annotation.Nullable;
+
 /**
  * GitHub secret.
  *
@@ -24,6 +26,7 @@ package io.micronaut.starter.feature.github.workflows;
 public class Secret {
 
     private final String name;
+    @Nullable
     private final String value;
     private final String description;
 
@@ -31,7 +34,7 @@ public class Secret {
         this(name, null, description);
     }
 
-    public Secret(String name, String value, String description) {
+    public Secret(String name, @Nullable String value, String description) {
         this.name = name;
         this.value = value;
         this.description = description;
@@ -60,6 +63,7 @@ public class Secret {
      *
      * @return the secret value
      */
+    @Nullable
     public String getValue() {
         return value;
     }

--- a/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/github/workflows/docker/AbstractDockerRegistryWorkflow.java
+++ b/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/github/workflows/docker/AbstractDockerRegistryWorkflow.java
@@ -52,6 +52,7 @@ public abstract class AbstractDockerRegistryWorkflow extends GitHubWorkflowFeatu
      *
      * @param generatorContext The context for project generation.
      */
+    @Override
     public void apply(GeneratorContext generatorContext) {
         ModuleContext module = generatorContext.getRootModule();
         if (OptionUtils.hasMavenBuildTool(generatorContext.getOptions())) {

--- a/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/jobrunr/JobRunrFeature.java
+++ b/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/jobrunr/JobRunrFeature.java
@@ -16,7 +16,6 @@
 package io.micronaut.starter.feature.jobrunr;
 
 import io.micronaut.context.annotation.Requires;
-import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.projectgen.core.openrewrite.OpenRewriteFeature;
 import io.micronaut.projectgen.core.generator.GeneratorContext;
@@ -60,7 +59,6 @@ public class JobRunrFeature implements MicronautCommunityFeature, OpenRewriteFea
     }
 
     @Override
-    @Nullable
     public String getDescription() {
         return "Micronaut integration for JobRunr background processing in Java";
     }

--- a/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/k8s/Kubernetes.java
+++ b/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/k8s/Kubernetes.java
@@ -81,6 +81,7 @@ public class Kubernetes implements OpenRewriteFeature {
      *
      * @param featureContext the feature context to process and modify
      */
+    @Override
     public void processSelectedFeatures(FeatureContext featureContext) {
         if (!featureContext.isPresent(Management.class)) {
             featureContext.addFeature(management);

--- a/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/knative/Knative.java
+++ b/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/knative/Knative.java
@@ -80,6 +80,7 @@ public class Knative implements Feature {
      *
      * @param featureContext the feature context to process and modify
      */
+    @Override
     public void processSelectedFeatures(FeatureContext featureContext) {
         if (!featureContext.isPresent(Management.class)) {
             featureContext.addFeature(management);

--- a/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/lang/ApplicationRenderingContext.java
+++ b/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/lang/ApplicationRenderingContext.java
@@ -24,10 +24,11 @@ import io.micronaut.core.annotation.Nullable;
  */
 public abstract class ApplicationRenderingContext {
 
+    @Nullable
     private final String defaultEnvironment;
     private final boolean eagerSingletons;
 
-    protected ApplicationRenderingContext(String defaultEnvironment, boolean eagerSingletons) {
+    protected ApplicationRenderingContext(@Nullable String defaultEnvironment, boolean eagerSingletons) {
         this.defaultEnvironment = defaultEnvironment;
         this.eagerSingletons = eagerSingletons;
     }
@@ -73,6 +74,7 @@ public abstract class ApplicationRenderingContext {
      *
      * @return the default environment string, may be null
      */
+    @Nullable
     public String getDefaultEnvironment() {
         return defaultEnvironment;
     }

--- a/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/lang/groovy/GroovyApplication.java
+++ b/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/lang/groovy/GroovyApplication.java
@@ -107,7 +107,7 @@ public class GroovyApplication implements GroovyApplicationFeature {
         );
     }
 
-    private static String getDefaultEnvironment(ModuleContext module) {
+    private static @Nullable String getDefaultEnvironment(ModuleContext module) {
         return module.hasConfigurationByEnvironment(Environment.DEVELOPMENT) ? Environment.DEVELOPMENT : null;
     }
 

--- a/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/lang/groovy/GroovyApplicationRenderingContext.java
+++ b/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/lang/groovy/GroovyApplicationRenderingContext.java
@@ -17,6 +17,7 @@ package io.micronaut.starter.feature.lang.groovy;
 
 import com.fizzed.rocker.RockerOutput;
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.projectgen.micronaut.template.lang.groovy.contextConfigurer;
 import io.micronaut.starter.feature.lang.ApplicationRenderingContext;
 
@@ -26,7 +27,7 @@ import io.micronaut.starter.feature.lang.ApplicationRenderingContext;
  */
 public class GroovyApplicationRenderingContext extends ApplicationRenderingContext {
 
-    public GroovyApplicationRenderingContext(String defaultEnvironment, boolean eagerSingletons) {
+    public GroovyApplicationRenderingContext(@Nullable String defaultEnvironment, boolean eagerSingletons) {
         super(defaultEnvironment, eagerSingletons);
     }
 

--- a/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/lang/java/JavaApplication.java
+++ b/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/lang/java/JavaApplication.java
@@ -134,7 +134,7 @@ public class JavaApplication implements JavaApplicationFeature {
         );
     }
 
-    private static String getDefaultEnvironment(ModuleContext module) {
+    private static @Nullable String getDefaultEnvironment(ModuleContext module) {
         return module.hasConfigurationByEnvironment(Environment.DEVELOPMENT) ? Environment.DEVELOPMENT : null;
     }
 

--- a/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/lang/java/JavaApplicationRenderingContext.java
+++ b/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/lang/java/JavaApplicationRenderingContext.java
@@ -17,6 +17,7 @@ package io.micronaut.starter.feature.lang.java;
 
 import com.fizzed.rocker.RockerOutput;
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.projectgen.micronaut.template.lang.java.contextConfigurer;
 import io.micronaut.starter.feature.lang.ApplicationRenderingContext;
 
@@ -26,7 +27,7 @@ import io.micronaut.starter.feature.lang.ApplicationRenderingContext;
  */
 public class JavaApplicationRenderingContext extends ApplicationRenderingContext {
 
-    public JavaApplicationRenderingContext(String defaultEnvironment, boolean eagerSingletons) {
+    public JavaApplicationRenderingContext(@Nullable String defaultEnvironment, boolean eagerSingletons) {
         super(defaultEnvironment, eagerSingletons);
     }
 

--- a/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/lang/kotlin/Kotlin.java
+++ b/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/lang/kotlin/Kotlin.java
@@ -97,7 +97,7 @@ public class Kotlin implements LanguageFeature, OpenRewriteFeature {
      */
     protected void addKotlinVersionProperty(GeneratorContext generatorContext, ModuleContext module) {
         Coordinate coordinate = generatorContext.resolveCoordinate("kotlin-bom");
-        module.buildProperties().put("kotlinVersion", coordinate.getVersion());
+        module.buildProperties().put("kotlinVersion", java.util.Objects.requireNonNull(coordinate.getVersion()));
     }
 
     @Override

--- a/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/lang/kotlin/KotlinApplication.java
+++ b/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/lang/kotlin/KotlinApplication.java
@@ -121,7 +121,7 @@ public class KotlinApplication implements KotlinApplicationFeature {
         );
     }
 
-    private static String getDefaultEnvironment(ModuleContext moduleContext) {
+    private static @Nullable String getDefaultEnvironment(ModuleContext moduleContext) {
         return moduleContext.hasConfigurationByEnvironment(Environment.DEVELOPMENT) ? Environment.DEVELOPMENT : null;
     }
 

--- a/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/lang/kotlin/KotlinApplicationRenderingContext.java
+++ b/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/lang/kotlin/KotlinApplicationRenderingContext.java
@@ -17,6 +17,7 @@ package io.micronaut.starter.feature.lang.kotlin;
 
 import com.fizzed.rocker.RockerOutput;
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.projectgen.micronaut.template.lang.kotlin.contextConfigurer;
 import io.micronaut.starter.feature.lang.ApplicationRenderingContext;
 
@@ -28,7 +29,7 @@ import io.micronaut.starter.feature.lang.ApplicationRenderingContext;
  */
 public class KotlinApplicationRenderingContext extends ApplicationRenderingContext {
 
-    public KotlinApplicationRenderingContext(String defaultEnvironment, boolean eagerSingletons) {
+    public KotlinApplicationRenderingContext(@Nullable String defaultEnvironment, boolean eagerSingletons) {
         super(defaultEnvironment, eagerSingletons);
     }
 

--- a/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/oraclecloud/OracleCloudAutonomousDatabase.java
+++ b/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/oraclecloud/OracleCloudAutonomousDatabase.java
@@ -17,6 +17,7 @@ package io.micronaut.starter.feature.oraclecloud;
 
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.projectgen.core.openrewrite.OpenRewriteFeature;
 import io.micronaut.projectgen.core.generator.GeneratorContext;
@@ -82,16 +83,19 @@ public class OracleCloudAutonomousDatabase extends DatabaseDriverFeature impleme
     }
 
     @Override
+    @Nullable
     public String getJdbcUrl() {
         return null;
     }
 
     @Override
+    @Nullable
     public String getR2dbcUrl() {
         return null;
     }
 
     @Override
+    @Nullable
     public String getDriverClass() {
         return null;
     }

--- a/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/other/OpenRewrite.java
+++ b/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/other/OpenRewrite.java
@@ -107,9 +107,9 @@ public class OpenRewrite implements LanguageSpecificFeature {
         BuildProperties props = module.buildProperties();
         coordinateResolver.resolve(mavenPluginArtifactId)
             .ifPresent(coordinate -> props.put(
-                "openrewrite.maven.plugin.version", coordinate.getVersion()));
+                "openrewrite.maven.plugin.version", java.util.Objects.requireNonNull(coordinate.getVersion())));
         coordinateResolver.resolve("rewrite-micronaut")
-            .ifPresent(coordinate -> props.put("rewrite-micronaut.version", coordinate.getVersion()));
+            .ifPresent(coordinate -> props.put("rewrite-micronaut.version", java.util.Objects.requireNonNull(coordinate.getVersion())));
     }
 
     @Override

--- a/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/security/SecurityOAuth2Feature.java
+++ b/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/security/SecurityOAuth2Feature.java
@@ -25,6 +25,7 @@ import io.micronaut.projectgen.core.feature.FeatureContext;
  */
 public abstract class SecurityOAuth2Feature implements Feature {
     private final SecurityOAuth2 securityOAuth2;
+    @Nullable
     private final SecurityJWT securityJWT;
 
     public SecurityOAuth2Feature(SecurityOAuth2 securityOAuth2,

--- a/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/testresources/EaseTestingFeature.java
+++ b/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/testresources/EaseTestingFeature.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.starter.feature.testresources;
 
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.projectgen.core.feature.Feature;
 import io.micronaut.projectgen.core.feature.FeatureContext;
 import io.micronaut.starter.feature.database.TestContainers;
@@ -23,7 +24,9 @@ import io.micronaut.starter.feature.database.TestContainers;
  * Abstract base class for testing features integrating TestResources and TestContainers.
  */
 public abstract class EaseTestingFeature implements Feature {
+    @Nullable
     private final TestResources testResources;
+    @Nullable
     private final TestContainers testContainers;
 
     protected EaseTestingFeature() {
@@ -31,8 +34,8 @@ public abstract class EaseTestingFeature implements Feature {
         this.testResources = null;
     }
 
-    protected EaseTestingFeature(TestContainers testContainers,
-        TestResources testResources) {
+    protected EaseTestingFeature(@Nullable TestContainers testContainers,
+        @Nullable TestResources testResources) {
         this.testContainers = testContainers;
         this.testResources = testResources;
     }

--- a/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/view/JTE.java
+++ b/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/view/JTE.java
@@ -94,9 +94,9 @@ public class JTE implements ViewFeature, MicronautServerDependent, OpenRewriteFe
         Coordinate coordinate = generatorContext.resolveCoordinate(MAVEN_PLUGIN_ARTIFACT_ID);
         return MavenPlugin.builder()
             .artifactId(MAVEN_PLUGIN_ARTIFACT_ID)
-            .extension(new RockerWritable(mvnPluginJTE.template(coordinate.getGroupId(),
+            .extension(new RockerWritable(mvnPluginJTE.template(java.util.Objects.requireNonNull(coordinate.getGroupId()),
                 coordinate.getArtifactId(),
-                coordinate.getVersion(),
+                java.util.Objects.requireNonNull(coordinate.getVersion()),
                 JTE_SRC_DIR)))
             .build();
     }

--- a/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/view/React.java
+++ b/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/view/React.java
@@ -118,7 +118,7 @@ public class React implements ViewFeature, MicronautServerDependent, OpenRewrite
                     module.addBuildPlugin(
                         MavenPlugin.builder()
                             .artifactId(StarterCoordinates.FRONTEND_MAVEN_PLUGIN.getArtifactId())
-                            .extension(new RockerWritable(mvnPluginReact.template(coordinate.getGroupId(), coordinate.getArtifactId(), coordinate.getVersion())))
+                            .extension(new RockerWritable(mvnPluginReact.template(java.util.Objects.requireNonNull(coordinate.getGroupId()), coordinate.getArtifactId(), java.util.Objects.requireNonNull(coordinate.getVersion()))))
                             .build()
                     );
                 }

--- a/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/view/Rocker.java
+++ b/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/view/Rocker.java
@@ -67,9 +67,9 @@ public class Rocker implements ViewFeature, MicronautServerDependent, OpenRewrit
         Coordinate coordinate = generatorContext.resolveCoordinate(mavenPluginArtifactId);
         module.addBuildPlugin(MavenPlugin.builder()
             .artifactId(mavenPluginArtifactId)
-            .extension(new RockerWritable(mvnPluginRocker.template(coordinate.getGroupId(),
+            .extension(new RockerWritable(mvnPluginRocker.template(java.util.Objects.requireNonNull(coordinate.getGroupId()),
                 coordinate.getArtifactId(),
-                coordinate.getVersion(),
+                java.util.Objects.requireNonNull(coordinate.getVersion()),
                 rockerSrcDir(module))))
             .build());
     }

--- a/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/view/Thymeleaf.java
+++ b/projectgen-micronaut/src/main/java/io/micronaut/starter/feature/view/Thymeleaf.java
@@ -47,7 +47,7 @@ public class Thymeleaf implements ViewFeature, MicronautServerDependent, OpenRew
 
     /**
      *
-     * @deprecated Use {@link Thymeleaf(ViewsFieldset)} instead.
+     * @deprecated Use {@link #Thymeleaf(ViewsFieldset)} instead.
      */
     @Deprecated(forRemoval = true, since = "4.2.0")
     public Thymeleaf() {

--- a/projectgen-micronaut/src/main/resources/META-INF/native-image/io.micronaut.projectgen/micronaut-projectgen-micronaut/resource-config.json
+++ b/projectgen-micronaut/src/main/resources/META-INF/native-image/io.micronaut.projectgen/micronaut-projectgen-micronaut/resource-config.json
@@ -1,0 +1,9 @@
+{
+  "resources": {
+    "includes": [
+      {
+        "pattern": "io/micronaut/projectgen/micronaut/template/.*\\$PlainText\\.class$"
+      }
+    ]
+  }
+}

--- a/projectgen-openrewrite/src/main/java/io/micronaut/projectgen/openrewrite/DefaultRecipeFetcher.java
+++ b/projectgen-openrewrite/src/main/java/io/micronaut/projectgen/openrewrite/DefaultRecipeFetcher.java
@@ -38,6 +38,7 @@ import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.function.Function;
@@ -197,7 +198,7 @@ public class DefaultRecipeFetcher implements RecipeFetcher {
         Recipe resolvedRecipe = resolveRecipe(recipe);
         List<FileContents> result = new ArrayList<>();
         if (resolvedRecipe instanceof org.openrewrite.xml.CreateXmlFile createXmlFile) {
-            result.add(new FileContents(createXmlFile.getRelativeFileName(), createXmlFile.getFileContents()));
+            result.add(new FileContents(createXmlFile.getRelativeFileName(), Objects.requireNonNull(createXmlFile.getFileContents())));
         }
         for (Recipe r : resolvedRecipe.getRecipeList()) {
             result.addAll(findAllFilesContents(r));

--- a/projectgen-openrewrite/src/main/java/io/micronaut/projectgen/openrewrite/OpenRewriteConfiguration.java
+++ b/projectgen-openrewrite/src/main/java/io/micronaut/projectgen/openrewrite/OpenRewriteConfiguration.java
@@ -17,6 +17,8 @@ package io.micronaut.projectgen.openrewrite;
 
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.projectgen.core.options.OperatingSystem;
+import org.jspecify.annotations.Nullable;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -33,8 +35,8 @@ import java.util.Objects;
  */
 public record OpenRewriteConfiguration(List<String> activeRecipes,
                                        boolean exportDatatables,
-                                       String recipeChangeLogLevel,
-                                       String configLocation,
+                                       @Nullable String recipeChangeLogLevel,
+                                       @Nullable String configLocation,
                                        OperatingSystem operatingSystem) {
     private static final String SYS_PROPERTY_REWRITE_ACTIVE_RECIPES = "rewrite.activeRecipes";
     private static final String SYS_PROPERTY_REWRITE_EXPORT_DATATABLES = "rewrite.exportDatatables";
@@ -63,8 +65,12 @@ public record OpenRewriteConfiguration(List<String> activeRecipes,
             systemProperties.put(SYS_PROPERTY_REWRITE_ACTIVE_RECIPES, String.join(",", activeRecipes));
         }
         systemProperties.put(SYS_PROPERTY_REWRITE_EXPORT_DATATABLES, exportDatatables);
-        systemProperties.put(SYS_PROPERTY_REWRITE_RECIPE_CHANGE_LOG_LEVEL, recipeChangeLogLevel);
-        systemProperties.put(SYS_PROPERTY_REWRITE_CONFIG_LOCATION, configLocation);
+        if (recipeChangeLogLevel != null) {
+            systemProperties.put(SYS_PROPERTY_REWRITE_RECIPE_CHANGE_LOG_LEVEL, recipeChangeLogLevel);
+        }
+        if (configLocation != null) {
+            systemProperties.put(SYS_PROPERTY_REWRITE_CONFIG_LOCATION, configLocation);
+        }
         return systemProperties;
     }
 
@@ -82,8 +88,11 @@ public record OpenRewriteConfiguration(List<String> activeRecipes,
     public static class Builder {
         private final List<String> activeRecipes = new ArrayList<>();
         private boolean exportDatatables;
+        @Nullable
         private String recipeChangeLogLevel;
+        @Nullable
         private String configLocation;
+        @Nullable
         private OperatingSystem operatingSystem;
 
         /**

--- a/projectgen-openrewrite/src/main/java/io/micronaut/projectgen/openrewrite/ProjectGenPropertiesScanningRecipe.java
+++ b/projectgen-openrewrite/src/main/java/io/micronaut/projectgen/openrewrite/ProjectGenPropertiesScanningRecipe.java
@@ -25,6 +25,7 @@ import io.micronaut.projectgen.core.options.JdkVersion;
 import io.micronaut.projectgen.core.options.Language;
 import io.micronaut.projectgen.core.options.OperatingSystem;
 import io.micronaut.projectgen.core.options.TestFramework;
+import org.jspecify.annotations.Nullable;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.ScanningRecipe;
 import org.openrewrite.SourceFile;
@@ -44,6 +45,7 @@ import static io.micronaut.projectgen.openrewrite.PropertiesUtils.parseValue;
  */
 @Internal
 public abstract class ProjectGenPropertiesScanningRecipe extends ScanningRecipe<GenericOptionsBuilder> {
+    @Nullable
     protected Path projectDir;
 
     @Override

--- a/projectgen-test/src/main/java/io/micronaut/projectgen/test/BuildTestVerifier.java
+++ b/projectgen-test/src/main/java/io/micronaut/projectgen/test/BuildTestVerifier.java
@@ -23,6 +23,7 @@ import io.micronaut.projectgen.core.options.Language;
 import io.micronaut.projectgen.core.options.Options;
 import io.micronaut.projectgen.core.options.TestFramework;
 import io.micronaut.projectgen.core.utils.OptionUtils;
+import org.jspecify.annotations.Nullable;
 
 /**
  * You can get an instance via {@link BuildTestVerifier#of(String, Options)}.
@@ -42,6 +43,7 @@ public interface BuildTestVerifier {
      * @param propertyName property name
      * @return the value associated with the property
      */
+    @Nullable
     default String getProperty(String propertyName) {
         throw new UnsupportedOperationException("Not supported yet.");
     }
@@ -199,10 +201,14 @@ public interface BuildTestVerifier {
     @NonNull
     static BuildTestVerifier of(@NonNull String template, @NonNull Options options) {
         if (OptionUtils.hasGradleBuildTool(options)) {
-            return new GradleBuildTestVerifier(template, options.getBuildTool(), options.language(), options.testFramework());
+            BuildTool buildTool = options.getBuildTool() == null ? BuildTool.GRADLE : options.getBuildTool();
+            Language language = options.language() == null ? Language.JAVA : options.language();
+            TestFramework testFramework = options.testFramework() == null ? TestFramework.DEFAULT_OPTION : options.testFramework();
+            return new GradleBuildTestVerifier(template, buildTool, language, testFramework);
         }
         if (OptionUtils.hasMavenBuildTool(options)) {
-            return new MavenBuildTestVerifier(template, options.language());
+            Language language = options.language() == null ? Language.JAVA : options.language();
+            return new MavenBuildTestVerifier(template, language);
         }
         throw new IllegalArgumentException("Options does not support Gradle or Maven");
     }

--- a/projectgen-test/src/main/java/io/micronaut/projectgen/test/MavenBuildTestVerifier.java
+++ b/projectgen-test/src/main/java/io/micronaut/projectgen/test/MavenBuildTestVerifier.java
@@ -24,6 +24,7 @@ import io.micronaut.projectgen.core.buildtools.maven.MavenScope;
 import io.micronaut.projectgen.core.buildtools.maven.ParentPom;
 import io.micronaut.projectgen.core.buildtools.maven.Profile;
 import io.micronaut.projectgen.core.options.Language;
+import org.jspecify.annotations.Nullable;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -37,6 +38,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -44,6 +46,7 @@ import java.util.Optional;
  */
 public class MavenBuildTestVerifier implements BuildTestVerifier {
     public static final Scope MAVEN_DEFAULT_SCOPE = Scope.COMPILE;
+    @Nullable
     private ParentPom parentPom;
     private final List<Profile> profiles = new ArrayList<>();
     private final List<Coordinate> buildPlugins  = new ArrayList<>();
@@ -81,6 +84,7 @@ public class MavenBuildTestVerifier implements BuildTestVerifier {
         }
     }
 
+    @Nullable
     private ParentPom parseParent(Element projectElement) {
         NodeList parentNodes = projectElement.getElementsByTagName("parent");
         if (parentNodes.getLength() == 0) {
@@ -94,7 +98,7 @@ public class MavenBuildTestVerifier implements BuildTestVerifier {
         String version = getElementText(parentElement, "version");
         String relativePath = getElementText(parentElement, "relativePath");
 
-        return new ParentPom(groupId, artifactId, version, relativePath);
+        return new ParentPom(groupId, Objects.requireNonNull(artifactId), version, relativePath);
     }
 
     private List<Coordinate> parseBuildPlugins(Element projectElement) {
@@ -109,7 +113,7 @@ public class MavenBuildTestVerifier implements BuildTestVerifier {
                 String artifactId = getElementText(pluginElement, "artifactId");
                 buildPlugins.add(Dependency.builder()
                     .groupId(groupId)
-                    .artifactId(artifactId)
+                    .artifactId(Objects.requireNonNull(artifactId))
                     .build());
             }
         }
@@ -159,7 +163,7 @@ public class MavenBuildTestVerifier implements BuildTestVerifier {
                             String pathArtifactId = getElementText(path, "artifactId");
                             result.add(Dependency.builder()
                                     .groupId(groupId)
-                                    .artifactId(pathArtifactId)
+                                    .artifactId(Objects.requireNonNull(pathArtifactId))
                                 .build());
                         }
                     }
@@ -182,7 +186,7 @@ public class MavenBuildTestVerifier implements BuildTestVerifier {
                 Element profileElement = (Element) profileNodes.item(i);
                 String id = getElementText(profileElement, "id");
                 result.add(Profile.builder()
-                    .id(id)
+                    .id(Objects.requireNonNull(id))
                     .build());
             }
         }
@@ -202,11 +206,11 @@ public class MavenBuildTestVerifier implements BuildTestVerifier {
                 String artifactId = getElementText(dependencyElement, "artifactId");
                 String version = getElementText(dependencyElement, "version");
                 String scope = getElementText(dependencyElement, "scope");
-                Optional<MavenScope> mavenScope = MavenScope.of(scope);
+                Optional<MavenScope> mavenScope = scope == null ? Optional.empty() : MavenScope.of(scope);
                 Dependency.Builder dependencyBuilder = Dependency.builder();
                 dependencyBuilder
                     .groupId(groupId)
-                    .artifactId(artifactId)
+                    .artifactId(Objects.requireNonNull(artifactId))
                     .version(version);
                 mavenScope.flatMap(MavenScope::toScope).ifPresent(dependencyBuilder::scope);
                 result.add(dependencyBuilder.build());
@@ -216,6 +220,7 @@ public class MavenBuildTestVerifier implements BuildTestVerifier {
     }
 
     // Helper method to get text content of an element
+    @Nullable
     private static String getElementText(Element parentElement, String tagName) {
         NodeList nodeList = parentElement.getElementsByTagName(tagName);
         if (nodeList.getLength() > 0) {
@@ -225,6 +230,7 @@ public class MavenBuildTestVerifier implements BuildTestVerifier {
     }
 
     @Override
+    @Nullable
     public String getProperty(String propertyName) {
         return properties.get(propertyName);
     }
@@ -276,8 +282,14 @@ public class MavenBuildTestVerifier implements BuildTestVerifier {
      */
     public boolean hasDependency(String groupId, String artifactId, MavenScope scope) {
         return dependencies.stream().anyMatch(d ->
-            matchCoordinateGroupIdAndArtifactId(d, groupId, artifactId) &&
-                MavenScope.of(d.getScope(), language).isPresent() && MavenScope.of(d.getScope(), language).get().equals(scope));
+            matchCoordinateGroupIdAndArtifactId(d, groupId, artifactId) && matchesMavenScope(d, scope));
+    }
+
+    private boolean matchesMavenScope(Dependency dependency, MavenScope scope) {
+        Scope dependencyScope = dependency.getScope();
+        return dependencyScope != null && MavenScope.of(dependencyScope, language)
+            .map(scope::equals)
+            .orElse(false);
     }
 
     @Override
@@ -341,7 +353,7 @@ public class MavenBuildTestVerifier implements BuildTestVerifier {
         if (parentPom == null) {
             return false;
         }
-        return parentPom.groupId().equals(groupId) && parentPom.artifactId().equals(artifactId);
+        return Objects.equals(parentPom.groupId(), groupId) && parentPom.artifactId().equals(artifactId);
     }
 
     @Override

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,10 +6,10 @@ pluginManagement {
 }
 
 plugins {
-    id 'io.micronaut.build.shared.settings' version '8.0.0-M18'
+    id 'io.micronaut.build.shared.settings' version '8.0.0'
 }
 
-rootProject.name = 'projectgen'
+rootProject.name = 'projectgen-parent'
 
 include 'projectgen-core'
 include 'projectgen-bom'

--- a/test-suite-helloworld-cli/build.gradle.kts
+++ b/test-suite-helloworld-cli/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-    id("io.micronaut.application") version "4.5.4"
-    id("com.gradleup.shadow") version "8.3.9"
+    id("io.micronaut.application") version "5.0.0"
+    id("com.gradleup.shadow") version "9.4.2"
 }
 version = "0.1"
 group = "io.micronaut.projectgen.demo"

--- a/test-suite-helloworld-http/build.gradle.kts
+++ b/test-suite-helloworld-http/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-    id("io.micronaut.application") version "4.5.4"
-    id("com.gradleup.shadow") version "8.3.9"
+    id("io.micronaut.application") version "5.0.0"
+    id("com.gradleup.shadow") version "9.4.2"
 }
 version = "0.1"
 group = "io.micronaut.projectgen.demo"

--- a/test-suite-helloworld-http/src/test/java/io/micronaut/projectgen/demo/DiffTest.java
+++ b/test-suite-helloworld-http/src/test/java/io/micronaut/projectgen/demo/DiffTest.java
@@ -9,17 +9,14 @@ import io.micronaut.projectgen.core.buildtools.BuildTool;
 import io.micronaut.projectgen.core.buildtools.gradle.GradleDsl;
 import io.micronaut.projectgen.core.options.JdkVersion;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
-import org.json.JSONException;
 import org.junit.jupiter.api.Test;
-import org.skyscreamer.jsonassert.JSONAssert;
-import org.skyscreamer.jsonassert.JSONCompareMode;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -46,17 +43,8 @@ class DiffTest {
             .contentType(MediaType.APPLICATION_FORM_URLENCODED_TYPE);
         String diff = assertDoesNotThrow(() -> client.retrieve(request));
         assertNotNull(diff);
+        assertFalse(diff.contains("--- projectgen.properties"), diff);
         String expected = """
-            --- projectgen.properties
-            +++ projectgen.properties
-            @@ -4,4 +4,5 @@
-             gradleDsl=KOTLIN
-             name=demo
-             packageName=com.example
-            +version=1.0.0
-             group=io.micronaut.projectgen""";
-        assertTrue(diff.contains(expected));
-        expected = """
             --- src/test/java/com/example/HelloWorldTest.java
             +++ src/test/java/com/example/HelloWorldTest.java
             @@ -1,0 +1,13 @@
@@ -77,11 +65,10 @@ class DiffTest {
         expected = """
             --- build.gradle.kts
             +++ build.gradle.kts
-            @@ -3,6 +3,13 @@
-                 id("application")
+            @@ -4,6 +4,12 @@
              }
              group = "io.micronaut.projectgen"
-            +version = "1.0.0"
+             version = "1.0.0"
             +repositories {
             +    mavenCentral()
             +}

--- a/test-suite-helloworld/src/main/java/io/micronaut/projectgen/demo/ProjectGenPropertiesFeatures.java
+++ b/test-suite-helloworld/src/main/java/io/micronaut/projectgen/demo/ProjectGenPropertiesFeatures.java
@@ -4,7 +4,9 @@ import io.micronaut.projectgen.core.feature.DefaultFeature;
 import io.micronaut.projectgen.core.feature.Feature;
 import io.micronaut.projectgen.core.generator.GeneratorContext;
 import io.micronaut.projectgen.core.generator.ModuleContext;
+import io.micronaut.projectgen.core.options.Language;
 import io.micronaut.projectgen.core.options.Options;
+import io.micronaut.projectgen.core.options.TestFramework;
 import io.micronaut.projectgen.core.template.PropertiesTemplate;
 import jakarta.inject.Singleton;
 
@@ -49,10 +51,10 @@ class ProjectGenPropertiesFeatures implements DefaultFeature {
         if (options.operatingSystem() != null) {
             props.put("operatingSystem", options.operatingSystem());
         }
-        if (options.template() != null) {
+        if (!"DEFAULT".equals(options.template())) {
             props.put("template", options.template());
         }
-        if (options.language() != null) {
+        if (options.language() != Language.JAVA) {
             props.put("language", options.language());
         }
         if (options.buildTools() != null) {
@@ -82,7 +84,7 @@ class ProjectGenPropertiesFeatures implements DefaultFeature {
         if (options.packaging() != null) {
             props.put("packaging", options.packaging());
         }
-        if (options.testFramework() != null) {
+        if (options.testFramework() != TestFramework.DEFAULT_OPTION) {
             props.put("testFramework", options.testFramework());
         }
         return props;


### PR DESCRIPTION
 Updates projectgen for Micronaut 5 OSS compatibility by moving annotations to JSpecify, handling nullable dependency scopes safely, excluding generated sources from Error Prone/Checkstyle, and bumping Micronaut platform/views to final releases. Also includes small test/build fixes for generated project verification.         